### PR TITLE
fix: Issue #28 Self-hosted runnerでのキャッシュ無効化とcompatibility_date更新

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -35,8 +35,9 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
+          # セルフホストランナーの制約によりキャッシュは無効
+          # cache: 'npm'
+          # cache-dependency-path: frontend/package-lock.json
       
       - name: Install dependencies
         run: npm ci

--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "saifuu-api",
-  "compatibility_date": "2024-09-23",
+  "compatibility_date": "2025-06-29",
   "compatibility_flags": ["nodejs_compat"],
   "main": "./src/index.tsx",
   "d1_databases": [


### PR DESCRIPTION
## Summary
- フロントエンドCIからキャッシュ設定を削除してSelf-hosted runnerの制約に対応
- APIのcompatibility_dateを最新版(2025-06-29)に更新
- CLAUDE.mdのSelf-hosted runner制約に準拠

## Changes
- `.github/workflows/frontend-ci.yml`: `cache: 'npm'`と`cache-dependency-path`設定を削除
- `api/wrangler.jsonc`: `compatibility_date`を`2024-09-23`から`2025-06-29`に更新

## Test plan
- [x] APIのタイプチェック・リント・ビルド確認
- [x] フロントエンドのタイプチェック・リント・ユニットテスト確認
- [x] すべてのテストが成功

Closes #28

🤖 Generated with [Claude Code](https://claude.ai/code)