### PR TITLE
chore: Issue #23 Dependabotを月一設定でセットアップ

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,72 @@
+version: 2
+updates:
+  # Frontend dependencies (Next.js, React, TypeScript, etc.)
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    # セルフホストランナーのリソース制約を考慮した設定
+    open-pull-requests-limit: 3
+    reviewers:
+      - "ryosuke-horie"
+    assignees:
+      - "ryosuke-horie"
+    labels:
+      - "dependencies"
+      - "frontend"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    # プロダクション依存関係を優先
+    target-branch: "main"
+    vendor: false
+    versioning-strategy: "increase"
+
+  # API dependencies (Hono, Drizzle, TypeScript, etc.)
+  - package-ecosystem: "npm"
+    directory: "/api"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "10:00"
+      timezone: "Asia/Tokyo"
+    # セルフホストランナーのリソース制約を考慮した設定
+    open-pull-requests-limit: 3
+    reviewers:
+      - "ryosuke-horie"
+    assignees:
+      - "ryosuke-horie"
+    labels:
+      - "dependencies"
+      - "api"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    # プロダクション依存関係を優先
+    target-branch: "main"
+    vendor: false
+    versioning-strategy: "increase"
+
+  # GitHub Actions workflow dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "11:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 2
+    reviewers:
+      - "ryosuke-horie"
+    assignees:
+      - "ryosuke-horie"
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    target-branch: "main"


### PR DESCRIPTION
## Summary
- Dependabotの月次自動更新設定を新規追加
- フロントエンド（Next.js、React等）とAPI（Hono、Drizzle等）、GitHub Actionsの依存関係を監視
- セルフホストランナーのリソース制約を考慮したPR数制限とスケジュール設定

## Test plan
- [x] .github/dependabot.yml ファイルの作成と設定確認
- [x] フロントエンド、API、GitHub Actions の各エコシステム設定
- [x] 月次スケジュール（毎月第一月曜日）とタイムゾーン（JST）設定
- [x] セルフホストランナー対応のPR制限（フロントエンド/API: 3件、CI: 2件）
- [x] 適切なレビュアー、アサイニー、ラベル設定

## 実装詳細
### 設定内容
- **スケジュール**: 毎月第一月曜日の日本時間9:00-11:00に実行
- **対象ディレクトリ**: `/frontend`, `/api`, `/` (GitHub Actions)
- **PR制限**: セルフホストランナーの負荷軽減のため制限設定
- **コミットメッセージ**: プロジェクトの規約に従った prefix 設定

### 考慮事項
- セルフホストランナーのリソース制約に配慮
- 月次実行により大量のPR生成を回避
- 適切なラベル付けで分類とレビュー効率化

Closes #23

🤖 Generated with [Claude Code](https://claude.ai/code)