### PR TITLE
fix: issue-57 Cloudflare Workers互換性日付を利用可能なバージョンに修正

### DIFF
--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "saifuu-api",
-  "compatibility_date": "2025-06-29",
+  "compatibility_date": "2025-06-17",
   "compatibility_flags": ["nodejs_compat"],
   "main": "./src/index.tsx",
   "d1_databases": [


### PR DESCRIPTION
## Summary
- Cloudflare Workers互換性日付を利用可能なバージョンに修正
- 開発環境でのAPIサーバー起動時の警告を解消

## 変更内容
- `api/wrangler.jsonc`の`compatibility_date`を`2025-06-29`から`2025-06-17`に変更
- インストールされているCloudflare Workersランタイムでサポートされている最新の日付に修正

## 関連Issue
Closes #57

## Test plan
- [x] APIサーバー起動時に互換性日付の警告が表示されないことを確認
- [x] 既存のAPI機能に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)