### PR TITLE
fix: issue-64 CIカバレッジレポートにフロントエンド/API識別を追加

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -68,7 +68,7 @@ jobs:
           
           # Create coverage comment
           {
-            echo "## 📊 Test Coverage Report"
+            echo "## 📊 Frontend Test Coverage Report"
             echo ""
             echo "| Metric | Coverage |"
             echo "|--------|----------|"


### PR DESCRIPTION
## Summary
- フロントエンドCIワークフローのカバレッジレポートタイトルを明確化
- 「Test Coverage Report」→「Frontend Test Coverage Report」に変更
- APIとフロントエンドのカバレッジレポートが同一PR内で区別可能に

## Changes
- `.github/workflows/frontend-ci.yml`のカバレッジレポートタイトルを修正
- API CI（`api-ci.yml`）は既に「API Test Coverage Report」として正しく表示済み

## Test plan
- [ ] 新しいPRでフロントエンドCIが実行されることを確認
- [ ] カバレッジレポートに「Frontend Test Coverage Report」が表示されることを確認
- [ ] APIとフロントエンドの両方が実行される場合に区別可能なことを確認

Closes #64

🤖 Generated with [Claude Code](https://claude.ai/code)