### PR TITLE
fix: issue-74 Workers Buildとの競合を避けるためCIからWrangler dry-run検証を除去

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -89,8 +89,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       # Cloudflare Workers向けの追加チェック
-      - name: Wrangler validation
-        run: npx wrangler deploy --dry-run --compatibility-date=2025-06-29
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      # NOTE: Wrangler dry-run validation removed to avoid conflicts with Workers Build automation
+      # See issue #74 for details

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,7 +174,8 @@ npm run test:e2e
 npm run test:unit
 
 # デプロイ（Cloudflare Workers）
-npm run deploy
+# 注意: Workers Build自動化との競合を避けるため、手動デプロイスクリプトは deploy:manual に変更されています
+npm run deploy:manual
 ```
 
 ## プロジェクト構造

--- a/api/package.json
+++ b/api/package.json
@@ -7,7 +7,7 @@
     "dev:e2e": "vite --port 3003",
     "build": "vite build",
     "preview": "$npm_execpath run build && vite preview",
-    "deploy": "$npm_execpath run build && wrangler deploy",
+    "deploy:manual": "$npm_execpath run build && wrangler deploy",
     "cf-typegen": "wrangler types --env-interface CloudflareBindings",
     "typecheck": "tsc --noEmit",
     "lint": "biome lint src/",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
 		"ci:check": "npm run typecheck && npm run lint:biome && npm run test:unit",
 		"storybook": "storybook dev -p 6006",
 		"build-storybook": "storybook build",
-		"deploy": "NODE_ENV=production opennextjs-cloudflare build && opennextjs-cloudflare deploy",
+		"deploy:manual": "NODE_ENV=production opennextjs-cloudflare build && opennextjs-cloudflare deploy",
 		"preview": "NODE_ENV=production opennextjs-cloudflare build && opennextjs-cloudflare preview",
 		"cf-typegen": "wrangler types --env-interface CloudflareEnv ./cloudflare-env.d.ts",
 		"test:e2e": "playwright test",


### PR DESCRIPTION
## Summary
- API CI からWrangler dry-run検証ステップを削除
- 手動デプロイスクリプトを deploy から deploy:manual に変更  
- ドキュメントを更新してWorkers Build自動化との競合を回避

## Test plan
- [x] API CI ワークフローからWrangler dry-run検証が削除されていることを確認
- [x] 手動デプロイスクリプトが deploy:manual に変更されていることを確認
- [x] ドキュメントが適切に更新されていることを確認

Closes #74

🤖 Generated with [Claude Code](https://claude.ai/code)