### PR TITLE
fix: issue-89 Cloudflare Workers BuildでのAPI/Frontendデプロイ失敗を解決

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -7,7 +7,7 @@
     "dev:e2e": "vite --port 3003",
     "build": "vite build",
     "preview": "$npm_execpath run build && vite preview",
-    "deploy": "$npm_execpath run build && wrangler deploy",
+    "deploy": "wrangler deploy",
     "deploy:manual": "$npm_execpath run build && wrangler deploy",
     "cf-typegen": "wrangler types --env-interface CloudflareBindings",
     "typecheck": "tsc --noEmit",

--- a/api/package.json
+++ b/api/package.json
@@ -7,6 +7,7 @@
     "dev:e2e": "vite --port 3003",
     "build": "vite build",
     "preview": "$npm_execpath run build && vite preview",
+    "deploy": "$npm_execpath run build && wrangler deploy",
     "deploy:manual": "$npm_execpath run build && wrangler deploy",
     "cf-typegen": "wrangler types --env-interface CloudflareBindings",
     "typecheck": "tsc --noEmit",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
 		"ci:check": "npm run typecheck && npm run lint:biome && npm run test:unit",
 		"storybook": "storybook dev -p 6006",
 		"build-storybook": "storybook build",
-		"deploy": "NODE_ENV=production opennextjs-cloudflare build && opennextjs-cloudflare deploy",
+		"deploy": "opennextjs-cloudflare deploy",
 		"deploy:manual": "NODE_ENV=production opennextjs-cloudflare build && opennextjs-cloudflare deploy",
 		"preview": "NODE_ENV=production opennextjs-cloudflare build && opennextjs-cloudflare preview",
 		"cf-typegen": "wrangler types --env-interface CloudflareEnv ./cloudflare-env.d.ts",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
 		"ci:check": "npm run typecheck && npm run lint:biome && npm run test:unit",
 		"storybook": "storybook dev -p 6006",
 		"build-storybook": "storybook build",
+		"deploy": "NODE_ENV=production opennextjs-cloudflare build && opennextjs-cloudflare deploy",
 		"deploy:manual": "NODE_ENV=production opennextjs-cloudflare build && opennextjs-cloudflare deploy",
 		"preview": "NODE_ENV=production opennextjs-cloudflare build && opennextjs-cloudflare preview",
 		"cf-typegen": "wrangler types --env-interface CloudflareEnv ./cloudflare-env.d.ts",


### PR DESCRIPTION
## Summary
Cloudflare Workers BuildでのAPI/Frontendデプロイ失敗を解決しました。

- API/Frontendの両方のpackage.jsonに不足していた`deploy`スクリプトを追加
- Cloudflare Workers Buildが期待する`npm run deploy`コマンドが実行できるように修正
- ビルドは前段で実行されるため、deployスクリプトは純粋なデプロイ処理のみに設定

### デプロイスクリプトの内容
- **Frontend**: `opennextjs-cloudflare deploy`
- **API**: `wrangler deploy`

## Test plan
- [x] デプロイスクリプトの動作確認（ローカルで実行済み）
- [x] Frontend/APIのビルド成功確認
- [x] TypeScript/Lint/Testの品質チェック通過確認

Closes #89

🤖 Generated with [Claude Code](https://claude.ai/code)