### PR TITLE
docs: issue-184 Ghostツールの導入とバックグラウンドプロセス管理ルールの追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,28 @@ docs/
 - **更新**: ドキュメントは実装と同時に更新し、常に最新状態を保つ
 - **禁止事項**: `frontend/docs/`、`api/docs/`、`.storybook/`等の分散配置は行わない
 
+### 8. バックグラウンドプロセス管理（Ghost）
+
+**重要**: 開発サーバの起動などセッションを占有するプロセスは、`ghost` ツールを使用してバックグラウンドで実行すること
+
+- **使用場面**: 開発サーバーの起動やその他の長時間実行されるプロセスを実行する場合
+- **禁止事項**: `npm run dev &` のような形式でのバックグラウンド実行は使用しない
+- **基本的な使い方**:
+  ```bash
+  # 開発サーバーをバックグラウンドで起動
+  ghost run npm run dev
+  
+  # プロセスの一覧確認
+  ghost list
+  
+  # ログの確認
+  ghost log <task-id>
+  
+  # プロセスの停止
+  ghost stop <task-id>
+  ```
+- **詳細な使い方**: [Ghostツール使用ガイド](./docs/tools/ghost使用ガイド.md)を参照
+
 ## 開発環境セットアップ
 
 ### 1. 前提条件
@@ -162,8 +184,10 @@ node --version
 ## スクリプト
 
 ```bash
-# 開発サーバー起動(あなた(=Claude)は開発サーバーの起動を行うと他の作業ができなくなるため、ユーザー(=開発者)に別セッションでの起動を依頼すること。)
-npm run  dev
+# 開発サーバー起動
+# 重要: バックグラウンドで実行する場合は必ずghostを使用すること
+ghost run npm run dev
+# または、ユーザーに別セッションでの起動を依頼
 
 # 型チェックとリント修正
 npm run check:fix
@@ -171,8 +195,8 @@ npm run check:fix
 # ビルド
 npm run build
 
-# Storybook起動
-npm run storybook
+# Storybook起動（バックグラウンド実行の場合）
+ghost run npm run storybook
 
 # Storybookビルド
 npm run build-storybook
@@ -192,6 +216,12 @@ npm run test:unit
 # デプロイ（Cloudflare Workers）
 # 注意: Workers Build自動化との競合を避けるため、手動デプロイスクリプトは deploy:manual に変更されています
 npm run deploy:manual
+
+# Ghostプロセス管理
+ghost list                     # 実行中のプロセス一覧
+ghost log <task-id>           # ログ確認
+ghost stop <task-id>          # プロセス停止
+ghost cleanup --days 7        # 古いタスクのクリーンアップ
 ```
 
 ## プロジェクト構造

--- a/docs/tools/ghost使用ガイド.md
+++ b/docs/tools/ghost使用ガイド.md
@@ -1,0 +1,216 @@
+# Ghost - バックグラウンドプロセスマネージャー使用ガイド
+
+## 概要
+
+Ghostは、Unix系システム（Linux、macOS、BSD）向けのシンプルなバックグラウンドプロセスマネージャーです。デーモンを必要とせず、コマンドをバックグラウンドで実行・管理できます。
+
+このドキュメントでは、Saifuuプロジェクトにおける開発サーバーやその他の長時間実行プロセスの管理方法について説明します。
+
+## インストール方法
+
+### 前提条件
+
+- Unix系システム（Linux、macOS、BSD）
+- Rust 1.80以上（2024 edition）
+
+### ソースからビルド
+
+```bash
+# リポジトリのクローン
+git clone https://github.com/skanehira/ghost.git
+cd ghost
+
+# リリースビルド
+cargo build --release
+```
+
+バイナリは `target/release/ghost` に生成されます。
+
+### システムへのインストール
+
+```bash
+# ローカルのbinディレクトリにコピー
+cp target/release/ghost ~/.local/bin/
+
+# またはシステムのbinディレクトリにコピー（sudoが必要）
+sudo cp target/release/ghost /usr/local/bin/
+```
+
+## Saifuuプロジェクトでの使い方
+
+### 開発サーバーの起動
+
+```bash
+# フロントエンドの開発サーバーをバックグラウンドで起動
+ghost run npm run dev
+
+# タスクIDとログファイルの場所が表示される
+Started background process:
+  Task ID: 83efed6c-ae7d-4c26-8993-5d2d1a83b64f
+  PID: 11203
+  Log file: /Users/user/Library/Application Support/ghost/logs/83efed6c-ae7d-4c26-8993-5d2d1a83b64f.log
+```
+
+### 実行中のプロセス確認
+
+```bash
+# すべてのタスクを一覧表示
+ghost list
+
+# 実行中のタスクのみ表示
+ghost list --status running
+```
+
+出力例：
+```
+Task ID                              PID      Status     Started              Command                        Directory
+--------------------------------------------------------------------------------------------------------------------------------------
+e56ed5f8-44c8-4905-97aa-651164afd37e 8969     running    2025-07-01 15:36     npm run dev                    /home/user/saifuu
+```
+
+### ログの確認
+
+```bash
+# タスクのログを表示
+ghost log e56ed5f8-44c8-4905-97aa-651164afd37e
+
+# リアルタイムでログを追跡（tail -f と同様）
+ghost log -f e56ed5f8-44c8-4905-97aa-651164afd37e
+```
+
+### タスクの詳細情報
+
+```bash
+# タスクの詳細情報を表示
+ghost status e56ed5f8-44c8-4905-97aa-651164afd37e
+```
+
+出力例：
+```
+Task: e56ed5f8-44c8-4905-97aa-651164afd37e
+PID: 8969
+Status: running
+Command: npm run dev
+Working directory: /home/user/saifuu
+Started: 2025-07-01 15:36:23
+Log file: /Users/user/Library/Application Support/ghost/logs/e56ed5f8-44c8-4905-97aa-651164afd37e.log
+```
+
+### プロセスの停止
+
+```bash
+# 正常終了（SIGTERM）
+ghost stop e56ed5f8-44c8-4905-97aa-651164afd37e
+
+# 強制終了（SIGKILL）
+ghost stop e56ed5f8-44c8-4905-97aa-651164afd37e --force
+```
+
+### 古いタスクのクリーンアップ
+
+```bash
+# 30日以上前のタスクを削除（デフォルト）
+ghost cleanup
+
+# 7日以上前のタスクを削除
+ghost cleanup --days 7
+
+# すべての終了済みタスクを削除（注意）
+ghost cleanup --all
+
+# 削除される内容をプレビュー（実際には削除しない）
+ghost cleanup --dry-run
+```
+
+## TUIモード
+
+GhostはインタラクティブなTerminal User Interface（TUI）も提供しています：
+
+```bash
+# TUIモードの起動
+ghost
+```
+
+### TUIのキーバインディング
+
+**タスクリスト：**
+- `j`/`k`: 選択を上下に移動
+- `g`/`G`: リストの先頭/末尾にジャンプ
+- `l`: 選択したタスクのログを表示
+- `s`: 選択したタスクにSIGTERMを送信
+- `Ctrl+K`: 選択したタスクにSIGKILLを送信
+- `q`: 終了
+- `Tab`: タスクフィルターの切り替え（All/Running/Exited/Killed）
+
+**ログビューア：**
+- `j`/`k`: 上下にスクロール
+- `h`/`l`: 左右にスクロール（長い行の場合）
+- `g`/`G`: 先頭/末尾にジャンプ
+- `Esc`: タスクリストに戻る
+
+## 主な機能
+
+- **デーモン不要**: 各コマンドが自己完結型
+- **プロセス分離**: タスクは独立したプロセスとして実行
+- **ログの永続化**: すべての出力がキャプチャされ保存される
+- **ステータス監視**: プロセスチェックによるリアルタイムの状態更新
+- **クロスプラットフォーム**: Unix系システムで動作
+
+## 設定
+
+### 環境変数
+
+- `GHOST_DATA_DIR`: デフォルトのデータディレクトリの場所を上書き
+
+### デフォルトの保存場所
+
+**Linux:**
+- データ: `$XDG_DATA_HOME/ghost` または `$HOME/.local/share/ghost`
+- ログ: `$XDG_DATA_HOME/ghost/logs` または `$HOME/.local/share/ghost/logs`
+
+**macOS:**
+- データ: `~/Library/Application Support/ghost/`
+- ログ: `~/Library/Application Support/ghost/logs/`
+
+## 実用的な使用例
+
+### 開発時の典型的なワークフロー
+
+```bash
+# 1. 開発サーバーをバックグラウンドで起動
+ghost run npm run dev
+
+# 2. タスクIDを確認
+ghost list --status running
+
+# 3. ログをリアルタイムで確認
+ghost log -f <task-id>
+
+# 4. 開発終了時にサーバーを停止
+ghost stop <task-id>
+
+# 5. 定期的に古いタスクをクリーンアップ
+ghost cleanup --days 7
+```
+
+### 複数のサービスを管理
+
+```bash
+# フロントエンドサーバーを起動
+ghost run --cwd /path/to/frontend npm run dev
+
+# APIサーバーを起動
+ghost run --cwd /path/to/api npm run dev
+
+# Storybookを起動
+ghost run npm run storybook
+
+# すべてのサービスを確認
+ghost list --status running
+```
+
+## 注意事項
+
+- `npm run dev &` のような形式でのバックグラウンド実行は使用しないこと
+- ghostを使用することで、プロセスの管理が一元化され、ログの確認や停止が容易になる
+- 開発セッションが終了してもプロセスは継続して実行されるため、必要に応じて手動で停止すること


### PR DESCRIPTION
## 概要

開発サーバーなどの長時間実行プロセスをバックグラウンドで適切に管理するため、Ghostツールの使用ルールをCLAUDE.mdに追加し、使用ガイドを作成しました。

## 変更内容

### CLAUDE.mdの更新
- 「### 8. バックグラウンドプロセス管理（Ghost）」セクションを追加
- `npm run dev &` のような形式でのバックグラウンド実行を禁止
- Ghostツールの使用を推奨するルールを明記
- スクリプトセクションにGhostコマンドの使用例を追加

### ドキュメントの作成
- `/docs/tools/ghost使用ガイド.md` を新規作成
- Ghostツールのインストール方法、使い方、実用例を日本語で詳細に記載
- Saifuuプロジェクトでの具体的な使用方法を説明

## 目的

- 開発中にセッションを占有せずに、バックグラウンドでプロセスを管理できるようにする
- プロセスの管理を一元化し、ログの確認や停止を容易にする
- チーム開発における開発環境の標準化

## 関連Issue

close #184

## 確認事項

- [x] CLAUDE.mdに新しいルールを追加
- [x] 日本語ドキュメントをdocs/ディレクトリに作成
- [x] 型チェックとLintが通過（npm run check:fix）
- [x] すべてのユニットテストが成功

## 参考

Ghostツール: https://github.com/skanehira/ghost