### PR TITLE
test: issue-187 フロントエンドのテストカバレッジを80%に引き上げる

### DIFF
--- a/frontend/src/lib/logger/__tests__/api-integration.test.ts
+++ b/frontend/src/lib/logger/__tests__/api-integration.test.ts
@@ -5,9 +5,19 @@
  * 最初は失敗します（Redフェーズ）
  */
 
+import { renderHook } from "@testing-library/react";
 import { createElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { apiClient } from "../../api/client";
+import {
+	createApiClientWithLogging,
+	createPerformanceMarker,
+	enhanceRequestWithLogging,
+	getErrorPerformance,
+	getResponsePerformance,
+	useApiLogger,
+	withApiLogging,
+} from "../api-integration";
 import { LoggerProvider } from "../context";
 
 // テスト用の設定
@@ -19,7 +29,7 @@ const testConfig = {
 	enableConsole: true,
 };
 
-const _wrapper = ({ children }: { children: React.ReactNode }) =>
+const wrapper = ({ children }: { children: React.ReactNode }) =>
 	createElement(LoggerProvider, { config: testConfig, children });
 
 describe("API統合とrequestId相関", () => {
@@ -134,34 +144,73 @@ describe("API統合とrequestId相関", () => {
 
 	describe("useApiLogger フック", () => {
 		it("APIログ機能が正常に動作する", () => {
-			// このテストは現在実装されていないため失敗します
-			expect(() => {
-				// const { useApiLogger } = require('../api-integration');
-				// const { result } = renderHook(() => useApiLogger(), { wrapper });
-				// expect(result.current.logApiCall).toBeDefined();
-				throw new Error("useApiLogger is not implemented");
-			}).toThrow("useApiLogger is not implemented");
+			const { result } = renderHook(() => useApiLogger(), { wrapper });
+
+			expect(result.current.logApiCall).toBeDefined();
+			expect(result.current.logApiSuccess).toBeDefined();
+			expect(result.current.logApiError).toBeDefined();
+			expect(typeof result.current.logApiCall).toBe("function");
+			expect(typeof result.current.logApiSuccess).toBe("function");
+			expect(typeof result.current.logApiError).toBe("function");
 		});
 
 		it("API成功時のログが正しく記録される", () => {
-			// このテストは現在実装されていないため失敗します
-			expect(() => {
-				// const { useApiLogger } = require('../api-integration');
-				// const { result } = renderHook(() => useApiLogger(), { wrapper });
-				// result.current.logApiSuccess('/test', 200, { requestId: 'test-123' });
-				throw new Error("logApiSuccess is not implemented");
-			}).toThrow("logApiSuccess is not implemented");
+			const { result } = renderHook(() => useApiLogger(), { wrapper });
+			const consoleInfoSpy = vi.spyOn(console, "info");
+
+			// API成功のログを記録
+			result.current.logApiSuccess("/test", 200, { requestId: "test-123" });
+
+			// ログが出力されたことを確認
+			expect(consoleInfoSpy).toHaveBeenCalledWith(
+				expect.stringMatching(/\[INFO\] API Success: \/test$/),
+				expect.objectContaining({
+					status: 200,
+					apiSuccess: true,
+					requestId: "test-123",
+				}),
+			);
 		});
 
 		it("APIエラー時のログが正しく記録される", () => {
-			// このテストは現在実装されていないため失敗します
-			expect(() => {
-				// const { useApiLogger } = require('../api-integration');
-				// const { result } = renderHook(() => useApiLogger(), { wrapper });
-				// const testError = new Error('API failed');
-				// result.current.logApiError('/test', testError, { requestId: 'test-123' });
-				throw new Error("logApiError is not implemented");
-			}).toThrow("logApiError is not implemented");
+			const { result } = renderHook(() => useApiLogger(), { wrapper });
+			const consoleErrorSpy = vi.spyOn(console, "error");
+			const testError = new Error("API failed");
+
+			// APIエラーのログを記録
+			result.current.logApiError("/test", testError, { requestId: "test-123" });
+
+			// エラーログが出力されたことを確認
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
+				expect.stringMatching(/\[ERROR\] API Error: \/test$/),
+				expect.objectContaining({
+					error: "API failed",
+					stack: expect.any(String),
+					apiError: true,
+					requestId: "test-123",
+				}),
+			);
+		});
+
+		it("API呼び出しのログが正しく記録される", () => {
+			const { result } = renderHook(() => useApiLogger(), { wrapper });
+			const consoleInfoSpy = vi.spyOn(console, "info");
+
+			// API呼び出しのログを記録
+			result.current.logApiCall("/test", "GET", { requestId: "test-123" });
+
+			// ログが出力されたことを確認
+			expect(consoleInfoSpy).toHaveBeenCalledWith(
+				expect.stringMatching(/\[INFO\] API call: GET \/test$/),
+				expect.objectContaining({
+					action: "api_call",
+					data: {
+						endpoint: "/test",
+						method: "GET",
+					},
+					requestId: "test-123",
+				}),
+			);
 		});
 	});
 
@@ -207,6 +256,158 @@ describe("API統合とrequestId相関", () => {
 			} finally {
 				mockFetch.mockRestore();
 			}
+		});
+	});
+
+	describe("createPerformanceMarker", () => {
+		it("パフォーマンス計測が正しく動作する", async () => {
+			const marker = createPerformanceMarker();
+
+			// 少し時間を経過させる
+			await new Promise((resolve) => setTimeout(resolve, 50));
+
+			const duration = marker.duration();
+			expect(duration).toBeGreaterThan(40); // 50ms待機したので40ms以上のはず
+			expect(duration).toBeLessThan(100); // 100ms未満のはず
+
+			// endメソッドも同じような値を返すことを確認（誤差を許容）
+			const endValue = marker.end();
+			expect(Math.abs(endValue - duration)).toBeLessThan(1); // 1ms以内の誤差は許容
+		});
+	});
+
+	describe("enhanceRequestWithLogging", () => {
+		it("fetchにrequestIdとパフォーマンス情報を追加する", async () => {
+			const mockResponse = new Response("test", { status: 200 });
+			const mockFetch = vi.fn().mockResolvedValue(mockResponse);
+
+			const enhancedFetch = enhanceRequestWithLogging(mockFetch);
+
+			const response = await enhancedFetch("/test");
+
+			// fetchが正しく呼ばれたことを確認
+			expect(mockFetch).toHaveBeenCalledWith(
+				"/test",
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						"X-Request-ID": expect.stringMatching(/^[0-9a-f-]{36}$/),
+					}),
+				}),
+			);
+
+			// レスポンスが返されることを確認
+			expect(response).toBe(mockResponse);
+		});
+
+		it("エラー時にもパフォーマンス情報を追加する", async () => {
+			const testError = new Error("Fetch failed");
+			const mockFetch = vi.fn().mockRejectedValue(testError);
+
+			const enhancedFetch = enhanceRequestWithLogging(mockFetch);
+
+			await expect(enhancedFetch("/test")).rejects.toThrow("Fetch failed");
+
+			// エラーにパフォーマンス情報が追加されていることを確認
+			const performance = getErrorPerformance(testError);
+			expect(performance).toBeTruthy();
+			expect(performance?.requestId).toMatch(/^[0-9a-f-]{36}$/);
+			expect(performance?.endpoint).toBe("/test");
+			expect(performance?.duration).toBeGreaterThan(0);
+		});
+	});
+
+	describe("createApiClientWithLogging", () => {
+		it("グローバルfetchを拡張し、復元できる", () => {
+			const originalFetch = globalThis.fetch;
+
+			// fetchを拡張
+			const { restore } = createApiClientWithLogging();
+
+			// fetchが変更されたことを確認
+			expect(globalThis.fetch).not.toBe(originalFetch);
+
+			// 復元
+			restore();
+
+			// 元のfetchに戻ったことを確認
+			expect(globalThis.fetch).toBe(originalFetch);
+		});
+	});
+
+	describe("getResponsePerformance/getErrorPerformance", () => {
+		it("レスポンスからパフォーマンス情報を取得できる", () => {
+			const mockResponse = new Response("test");
+			const performanceData = {
+				duration: 100,
+				requestId: "test-id",
+				endpoint: "/test",
+			};
+
+			// パフォーマンス情報を追加
+			Object.defineProperty(mockResponse, "__performance", {
+				value: performanceData,
+				writable: false,
+				enumerable: false,
+			});
+
+			const result = getResponsePerformance(mockResponse);
+			expect(result).toEqual(performanceData);
+		});
+
+		it("パフォーマンス情報がない場合はnullを返す", () => {
+			const mockResponse = new Response("test");
+			const result = getResponsePerformance(mockResponse);
+			expect(result).toBeNull();
+		});
+	});
+
+	describe("withApiLogging", () => {
+		it("APIクライアントのメソッドをラップする", async () => {
+			const mockClient = {
+				get: vi.fn().mockResolvedValue({ data: "test" }),
+				post: vi.fn().mockResolvedValue({ data: "created" }),
+				put: vi.fn().mockResolvedValue({ data: "updated" }),
+				delete: vi.fn().mockResolvedValue({ data: "deleted" }),
+			};
+
+			const wrappedClient = withApiLogging(mockClient);
+
+			// GETメソッドのテスト
+			await wrappedClient.get("/test");
+			expect(mockClient.get).toHaveBeenCalledWith(
+				"/test",
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						"X-Request-ID": expect.stringMatching(/^[0-9a-f-]{36}$/),
+					}),
+				}),
+			);
+
+			// ログが出力されたことを確認
+			expect(console.log).toHaveBeenCalledWith(
+				"[FRONTEND]",
+				"API call: GET /test",
+				expect.objectContaining({
+					method: "GET",
+					endpoint: "/test",
+					apiCall: true,
+				}),
+			);
+		});
+
+		it("メソッドが存在しないクライアントも処理できる", () => {
+			const mockClient = {
+				customMethod: vi.fn(),
+			};
+
+			const wrappedClient = withApiLogging(mockClient);
+
+			// カスタムメソッドは変更されない
+			expect(wrappedClient.customMethod).toBe(mockClient.customMethod);
+
+			// HTTPメソッドは存在しない
+			expect((wrappedClient as any).get).toBeUndefined();
+			expect((wrappedClient as any).post).toBeUndefined();
 		});
 	});
 });

--- a/frontend/src/middleware.test.ts
+++ b/frontend/src/middleware.test.ts
@@ -1,0 +1,211 @@
+/**
+ * middleware.ts のテスト
+ * requestId生成・ヘッダー設定・ログ出力機能を検証
+ */
+
+import { type NextRequest, NextResponse } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { generateRequestId } from "./lib/utils/request-id";
+import { config, middleware } from "./middleware";
+
+// モジュールのモック
+vi.mock("./lib/utils/request-id", () => ({
+	generateRequestId: vi.fn(),
+}));
+
+vi.mock("next/server", () => ({
+	NextResponse: {
+		next: vi.fn(),
+	},
+	NextRequest: vi.fn(),
+}));
+
+describe("middleware", () => {
+	const mockRequestId = "test-request-id-123";
+	const mockGenerateRequestId = vi.mocked(generateRequestId);
+	let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGenerateRequestId.mockReturnValue(mockRequestId);
+		consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		// NextResponse.next()のモック設定
+		const mockHeaders = new Map<string, string>();
+		const mockResponse = {
+			headers: {
+				set: vi.fn((key: string, value: string) => {
+					mockHeaders.set(key, value);
+				}),
+				get: vi.fn((key: string) => mockHeaders.get(key)),
+			},
+		};
+		vi.mocked(NextResponse.next).mockReturnValue(mockResponse as any);
+	});
+
+	afterEach(() => {
+		consoleLogSpy.mockRestore();
+		// NODE_ENVを元に戻す
+		vi.unstubAllEnvs();
+	});
+
+	describe("requestId処理", () => {
+		it("既存のX-Request-IDヘッダーがある場合はそれを使用する", () => {
+			const existingRequestId = "existing-request-id";
+			const mockRequest = {
+				headers: {
+					get: vi.fn((name: string) =>
+						name === "X-Request-ID" ? existingRequestId : null,
+					),
+				},
+				method: "GET",
+				url: "http://localhost:3000/",
+			} as unknown as NextRequest;
+
+			const response = middleware(mockRequest);
+
+			// generateRequestIdが呼ばれないことを確認
+			expect(mockGenerateRequestId).not.toHaveBeenCalled();
+
+			// レスポンスヘッダーに既存のrequestIdが設定されることを確認
+			expect(response.headers.set).toHaveBeenCalledWith(
+				"X-Request-ID",
+				existingRequestId,
+			);
+			expect(response.headers.set).toHaveBeenCalledWith(
+				"X-Saifuu-Request-ID",
+				existingRequestId,
+			);
+		});
+
+		it("X-Request-IDヘッダーがない場合は新規生成する", () => {
+			const mockRequest = {
+				headers: {
+					get: vi.fn(() => null),
+				},
+				method: "GET",
+				url: "http://localhost:3000/",
+			} as unknown as NextRequest;
+
+			const response = middleware(mockRequest);
+
+			// generateRequestIdが呼ばれることを確認
+			expect(mockGenerateRequestId).toHaveBeenCalledTimes(1);
+
+			// レスポンスヘッダーに新規生成されたrequestIdが設定されることを確認
+			expect(response.headers.set).toHaveBeenCalledWith(
+				"X-Request-ID",
+				mockRequestId,
+			);
+			expect(response.headers.set).toHaveBeenCalledWith(
+				"X-Saifuu-Request-ID",
+				mockRequestId,
+			);
+		});
+	});
+
+	describe("ログ出力", () => {
+		it("開発環境ではリクエスト情報をログに出力する", () => {
+			// NODE_ENVを開発環境に設定
+			vi.stubEnv("NODE_ENV", "development");
+
+			const mockRequest = {
+				headers: {
+					get: vi.fn(() => null),
+				},
+				method: "POST",
+				url: "http://localhost:3000/api/test",
+			} as unknown as NextRequest;
+
+			middleware(mockRequest);
+
+			// ログが出力されることを確認
+			expect(consoleLogSpy).toHaveBeenCalledWith(
+				`[MIDDLEWARE] POST http://localhost:3000/api/test - RequestID: ${mockRequestId}`,
+			);
+		});
+
+		it("本番環境ではログを出力しない", () => {
+			// NODE_ENVを本番環境に設定
+			vi.stubEnv("NODE_ENV", "production");
+
+			const mockRequest = {
+				headers: {
+					get: vi.fn(() => null),
+				},
+				method: "GET",
+				url: "http://localhost:3000/",
+			} as unknown as NextRequest;
+
+			middleware(mockRequest);
+
+			// ログが出力されないことを確認
+			expect(consoleLogSpy).not.toHaveBeenCalled();
+		});
+
+		it("テスト環境ではログを出力しない", () => {
+			// NODE_ENVをテスト環境に設定（デフォルト）
+			vi.stubEnv("NODE_ENV", "test");
+
+			const mockRequest = {
+				headers: {
+					get: vi.fn(() => null),
+				},
+				method: "GET",
+				url: "http://localhost:3000/",
+			} as unknown as NextRequest;
+
+			middleware(mockRequest);
+
+			// ログが出力されないことを確認
+			expect(consoleLogSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("レスポンス処理", () => {
+		it("NextResponse.next()を呼び出して正しいレスポンスを返す", () => {
+			const mockRequest = {
+				headers: {
+					get: vi.fn(() => null),
+				},
+				method: "GET",
+				url: "http://localhost:3000/",
+			} as unknown as NextRequest;
+
+			const response = middleware(mockRequest);
+
+			// NextResponse.next()が呼ばれることを確認
+			expect(NextResponse.next).toHaveBeenCalledTimes(1);
+
+			// レスポンスが正しく返されることを確認
+			expect(response).toBeDefined();
+			expect(response.headers.set).toBeDefined();
+		});
+	});
+});
+
+describe("middleware config", () => {
+	it("正しいmatcher設定を持つ", () => {
+		expect(config).toBeDefined();
+		expect(config.matcher).toBeDefined();
+		expect(Array.isArray(config.matcher)).toBe(true);
+		expect(config.matcher).toHaveLength(1);
+		expect(config.matcher[0]).toBe(
+			"/((?!api|_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+		);
+	});
+
+	it("APIルート、静的ファイル、画像ファイルを除外する", () => {
+		// Next.jsのmatcher設定はパスパターンを指定するもので、
+		// 正規表現として直接使用するものではない
+		const matcherPattern = config.matcher[0];
+
+		// matcherパターンが正しいフォーマットであることを確認
+		expect(matcherPattern).toContain("(?!");
+		expect(matcherPattern).toContain("api");
+		expect(matcherPattern).toContain("_next/static");
+		expect(matcherPattern).toContain("_next/image");
+		expect(matcherPattern).toContain("favicon.ico");
+		expect(matcherPattern).toContain("svg|png|jpg|jpeg|gif|webp");
+	});
+});


### PR DESCRIPTION
## Summary
- フロントエンドのテストカバレッジを77.84%から80.77%に引き上げました
- Issue #187 に対応
- 0%カバレッジのファイルを中心にテストを追加

## Changes
- `src/middleware.test.ts`: 新規作成し、requestId生成やヘッダー設定機能のテストを実装
- `src/app/global-error.test.tsx`: 既存テストを修正し、実際のコンポーネントをテストするように変更
- `src/lib/logger/__tests__/api-integration.test.ts`: 未実装だったテストケースを追加実装

## Test plan
- [x] ユニットテストが全て成功することを確認
- [x] テストカバレッジが80%以上であることを確認
- [x] 型チェックとリントが通ることを確認

Close #187

🤖 Generated with [Claude Code](https://claude.ai/code)