### PR TITLE
fix: issue-268 本番環境でFE/API間のリクエストが503エラーになる問題を修正

### DIFF
--- a/api/src/index.tsx
+++ b/api/src/index.tsx
@@ -21,9 +21,9 @@ app.use(
 	cors({
 		origin: [
 			'http://localhost:3000',
-			'http://localhost:3002',
-			'http://localhost:3003',
+			'http://localhost:3001',
 			'https://saifuu.ryosuke-horie37.workers.dev',
+			'https://saifuu.pages.dev',
 		],
 		allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
 		allowHeaders: ['Content-Type', 'Authorization'],


### PR DESCRIPTION
## 概要
本番環境（Cloudflare Pages）からAPIへのリクエストが503エラーとCORSエラーで失敗する問題を修正しました。

## 問題
- 本番環境URL `https://saifuu.pages.dev` からのリクエストが503エラーを返していた
- CORSエラーも同時に発生していた

## 変更内容
- APIのCORS設定に `https://saifuu.pages.dev` を追加
- 不要な開発環境ポート（localhost:3002, localhost:3003）を削除し、localhost:3001に統一

## 修正後のCORS許可オリジン
- `http://localhost:3000` - 開発環境（フロントエンド）
- `http://localhost:3001` - 開発環境（追加ポート）
- `https://saifuu.ryosuke-horie37.workers.dev` - 本番環境（Workers）
- `https://saifuu.pages.dev` - 本番環境（Cloudflare Pages） ✅ 新規追加

## テスト
- APIの型チェック・リント・ユニットテストが全てパス
- 本番環境でのCORSエラーが解消されることを確認する必要があります

Closes #268