### PR TITLE
fix: issue-277 本番環境のCORSエラーを修正

### DIFF
--- a/api/src/index.test.ts
+++ b/api/src/index.test.ts
@@ -1,0 +1,95 @@
+/**
+ * APIサーバーのCORS設定テスト
+ * 本番環境でのCORSエラーを防ぐための設定確認
+ */
+
+import { describe, expect, it } from 'vitest'
+import app from './index'
+
+describe('CORS設定', () => {
+	describe('許可されたヘッダー', () => {
+		it('X-Request-IDヘッダーが許可されていること', async () => {
+			// プリフライトリクエスト（OPTIONS）を送信
+			const response = await app.request('/api/test', {
+				method: 'OPTIONS',
+				headers: {
+					Origin: 'https://saifuu.ryosuke-horie37.workers.dev',
+					'Access-Control-Request-Method': 'GET',
+					'Access-Control-Request-Headers': 'X-Request-ID',
+				},
+			})
+
+			// CORSプリフライトが成功することを確認
+			expect(response.status).toBe(204)
+
+			// Access-Control-Allow-Headersにx-request-idが含まれていることを確認
+			const allowedHeaders = response.headers.get('Access-Control-Allow-Headers')
+			expect(allowedHeaders).toBeTruthy()
+			expect(allowedHeaders?.toLowerCase()).toContain('x-request-id')
+		})
+
+		it('他の必要なヘッダーも引き続き許可されていること', async () => {
+			const response = await app.request('/api/test', {
+				method: 'OPTIONS',
+				headers: {
+					Origin: 'https://saifuu.ryosuke-horie37.workers.dev',
+					'Access-Control-Request-Method': 'POST',
+					'Access-Control-Request-Headers': 'Content-Type, Authorization',
+				},
+			})
+
+			expect(response.status).toBe(204)
+			const allowedHeaders = response.headers.get('Access-Control-Allow-Headers')
+			expect(allowedHeaders?.toLowerCase()).toContain('content-type')
+			expect(allowedHeaders?.toLowerCase()).toContain('authorization')
+		})
+	})
+
+	describe('許可されたオリジン', () => {
+		it('本番環境のオリジンが許可されていること', async () => {
+			const response = await app.request('/api/test', {
+				method: 'OPTIONS',
+				headers: {
+					Origin: 'https://saifuu.ryosuke-horie37.workers.dev',
+					'Access-Control-Request-Method': 'GET',
+				},
+			})
+
+			expect(response.status).toBe(204)
+			expect(response.headers.get('Access-Control-Allow-Origin')).toBe(
+				'https://saifuu.ryosuke-horie37.workers.dev'
+			)
+		})
+
+		it('開発環境のオリジンも許可されていること', async () => {
+			const response = await app.request('/api/test', {
+				method: 'OPTIONS',
+				headers: {
+					Origin: 'http://localhost:3000',
+					'Access-Control-Request-Method': 'GET',
+				},
+			})
+
+			expect(response.status).toBe(204)
+			expect(response.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:3000')
+		})
+	})
+
+	describe('実際のリクエストでのCORS動作', () => {
+		it('X-Request-IDヘッダーを含むGETリクエストが成功すること', async () => {
+			// 実際のエンドポイントがない場合でも、CORSは機能するはず
+			const response = await app.request('/api/health', {
+				method: 'GET',
+				headers: {
+					Origin: 'https://saifuu.ryosuke-horie37.workers.dev',
+					'X-Request-ID': 'test-request-id-123',
+				},
+			})
+
+			// CORSヘッダーが正しく設定されていることを確認
+			expect(response.headers.get('Access-Control-Allow-Origin')).toBe(
+				'https://saifuu.ryosuke-horie37.workers.dev'
+			)
+		})
+	})
+})

--- a/api/src/index.tsx
+++ b/api/src/index.tsx
@@ -26,7 +26,7 @@ app.use(
 			'https://saifuu.pages.dev',
 		],
 		allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-		allowHeaders: ['Content-Type', 'Authorization'],
+		allowHeaders: ['Content-Type', 'Authorization', 'X-Request-ID'],
 	})
 )
 


### PR DESCRIPTION
## 概要
本番環境でCORSエラーが発生していた問題を修正します。

## 問題
- フロントエンドがAPIリクエストに `X-Request-ID` ヘッダーを送信
- API側のCORS設定で `X-Request-ID` が許可されていなかった
- 結果として本番環境でAPIリクエストがすべて失敗

## 修正内容
- API側のCORS設定の `allowHeaders` に `X-Request-ID` を追加
- CORS設定のユニットテストを追加し、今後の回帰を防止

## テスト
- ✅ CORS設定のユニットテストを追加
- ✅ すべてのテストがパス

Fixes #277

🤖 Generated with [Claude Code](https://claude.ai/code)