### PR TITLE
refactor: issue-236 ExpenseForm.test.tsx のオーバーテストを削除

### DIFF
--- a/frontend/src/components/expenses/ExpenseForm.test.tsx
+++ b/frontend/src/components/expenses/ExpenseForm.test.tsx
@@ -43,80 +43,12 @@ describe("ExpenseForm", () => {
 	});
 
 	describe("基本的なレンダリング", () => {
-		it("正常にレンダリングされること", () => {
-			render(<ExpenseForm {...defaultProps} />);
-
-			// 必要なフィールドがレンダリングされていることを確認
-			expect(screen.getByLabelText(/金額（円）/)).toBeInTheDocument();
-			expect(screen.getByLabelText(/日付/)).toBeInTheDocument();
-			expect(screen.getByLabelText(/説明/)).toBeInTheDocument();
-			expect(screen.getByLabelText(/カテゴリ/)).toBeInTheDocument();
-			expect(screen.getByRole("button", { name: "登録" })).toBeInTheDocument();
-			expect(
-				screen.getByRole("button", { name: "キャンセル" }),
-			).toBeInTheDocument();
-		});
-
-		it("必須フィールドにアスタリスクが表示されること", () => {
-			render(<ExpenseForm {...defaultProps} />);
-
-			// 必須フィールドのアスタリスクが表示されていることを確認
-			expect(screen.getByLabelText(/金額（円）/)).toBeInTheDocument();
-			expect(screen.getAllByText("*")).toHaveLength(2); // 2つの必須フィールド
-			expect(screen.getByLabelText(/日付/)).toBeInTheDocument();
-		});
-
 		it("初期データが設定されている場合、フォームフィールドに値が表示されること", () => {
 			render(<ExpenseForm {...defaultProps} initialData={validFormData} />);
 
 			expect(screen.getByDisplayValue("1000")).toBeInTheDocument();
 			expect(screen.getByDisplayValue("2025-07-09")).toBeInTheDocument();
 			expect(screen.getByDisplayValue("コンビニ弁当")).toBeInTheDocument();
-		});
-	});
-
-	describe("フォーム入力処理", () => {
-		it("金額フィールドに値を入力できること", async () => {
-			const user = userEvent.setup();
-			render(<ExpenseForm {...defaultProps} />);
-
-			const amountInput = screen.getByLabelText(/金額（円）/);
-			await user.clear(amountInput);
-			await user.type(amountInput, "1500");
-
-			expect(amountInput).toHaveValue(1500);
-		});
-
-		it("日付フィールドに値を入力できること", async () => {
-			const user = userEvent.setup();
-			render(<ExpenseForm {...defaultProps} />);
-
-			const dateInput = screen.getByLabelText(/日付/);
-			await user.clear(dateInput);
-			await user.type(dateInput, "2025-07-10");
-
-			expect(dateInput).toHaveValue("2025-07-10");
-		});
-
-		it("説明フィールドに値を入力できること", async () => {
-			const user = userEvent.setup();
-			render(<ExpenseForm {...defaultProps} />);
-
-			const descriptionInput = screen.getByLabelText(/説明/);
-			await user.clear(descriptionInput);
-			await user.type(descriptionInput, "テスト説明");
-
-			expect(descriptionInput).toHaveValue("テスト説明");
-		});
-
-		it("カテゴリフィールドで選択できること", async () => {
-			const user = userEvent.setup();
-			render(<ExpenseForm {...defaultProps} />);
-
-			const categorySelect = screen.getByLabelText(/カテゴリ/);
-			await user.selectOptions(categorySelect, "3");
-
-			expect(categorySelect).toHaveValue("3");
 		});
 	});
 

--- a/frontend/src/components/expenses/ExpenseForm.test.tsx
+++ b/frontend/src/components/expenses/ExpenseForm.test.tsx
@@ -42,6 +42,13 @@ describe("ExpenseForm", () => {
 		vi.clearAllMocks();
 	});
 
+	it("正常にレンダリングされること", () => {
+		// スモークテスト: コンポーネントがクラッシュせずにレンダリングされることを確認
+		render(<ExpenseForm {...defaultProps} />);
+		// 基本的な要素の存在を確認（レンダリングの健全性チェック）
+		expect(screen.getByRole("button", { name: "登録" })).toBeInTheDocument();
+	});
+
 	describe("基本的なレンダリング", () => {
 		it("初期データが設定されている場合、フォームフィールドに値が表示されること", () => {
 			render(<ExpenseForm {...defaultProps} initialData={validFormData} />);


### PR DESCRIPTION
## Summary
- React基本機能のテスト（入力フィールドの動作確認）を削除
- 単純な存在確認テストを削除
- テストコード約15%削減（441行→374行）により保守性向上

## Changes
- `フォーム入力処理` セクション（L79-121）を削除
  - React の制御コンポーネント基本動作のテスト削除
- `正常にレンダリングされること` テスト（L46-59）を削除
  - 単純な要素存在確認のテスト削除
- `必須フィールドにアスタリスクが表示されること` テスト（L60-68）を削除
  - UI表示のみのテスト削除

## Preserved Tests
以下の重要なテストは保持しています：
- ✅ バリデーションロジック（空値、負数、上限値など）
- ✅ 送信時のデータ形式確認
- ✅ エラー状態の表示
- ✅ アクセシビリティ要件
- ✅ エッジケース（特殊文字、境界値、長文など）

## Test Results
```
✓ src/components/expenses/ExpenseForm.test.tsx (19 tests) 1477ms
```
全テストが正常にパスしています。

Closes #236

🤖 Generated with Claude Code