### PR TITLE
feat: issue-324 支出管理画面でモバイル表示時に取引件数を非表示

### DIFF
--- a/frontend/src/app/expenses/page.tsx
+++ b/frontend/src/app/expenses/page.tsx
@@ -154,7 +154,7 @@ export default function ExpensesPage() {
 					</div>
 
 					{/* 取引件数 */}
-					<div className="bg-white overflow-hidden shadow rounded-lg">
+					<div className="bg-white overflow-hidden shadow rounded-lg hidden sm:block">
 						<div className="p-5">
 							<div className="flex items-center">
 								<div className="flex-shrink-0">


### PR DESCRIPTION
## Summary
- 支出管理画面において、スマートフォンサイズ（640px未満）で「取引件数」カードを非表示にしました
- `hidden sm:block` クラスを追加することで、レスポンシブ対応を実現

## 変更内容
- 📱 モバイル表示（640px未満）: 取引件数カードが非表示
- 💻 タブレット/デスクトップ（640px以上）: 従来通り表示

## 技術的詳細
- Tailwind CSSの`hidden`と`sm:block`クラスを使用
- 最小限の変更で要件を実現（1行のみの変更）

Closes #324

🤖 Generated with [Claude Code](https://claude.ai/code)