### PR TITLE
feat: issue-325 支出管理画面でモバイル表示時にカテゴリと備考を表示

### DIFF
--- a/frontend/src/components/expenses/ExpenseList.test.tsx
+++ b/frontend/src/components/expenses/ExpenseList.test.tsx
@@ -197,6 +197,96 @@ describe("ExpenseList", () => {
 		});
 	});
 
+	describe("モバイル表示", () => {
+		it("モバイル画面幅でもカテゴリと備考が表示される", () => {
+			// ウィンドウ幅をモバイルサイズに設定
+			global.innerWidth = 375;
+			global.dispatchEvent(new Event("resize"));
+
+			render(
+				<ExpenseList
+					transactions={mockTransactions}
+					isLoading={false}
+					error={null}
+				/>,
+			);
+
+			// カテゴリヘッダーが表示されていることを確認
+			const categoryHeader = screen.getByText("カテゴリ");
+			expect(categoryHeader).toBeVisible();
+
+			// 説明ヘッダーが表示されていることを確認
+			const descriptionHeader = screen.getByText("説明");
+			expect(descriptionHeader).toBeVisible();
+
+			// カテゴリデータが表示されていることを確認
+			// mockTransactionsには「その他」と「仕事・ビジネス」カテゴリが含まれている
+			const categoryCells = screen.getAllByText("その他");
+			expect(categoryCells.length).toBeGreaterThan(0);
+			expect(categoryCells[0]).toBeVisible();
+
+			// 説明データが表示されていることを確認
+			const descriptionCell = screen.getByText("昼食代（コンビニ弁当）");
+			expect(descriptionCell).toBeVisible();
+		});
+
+		// すべての画面サイズでカテゴリと説明が表示されることを確認
+		it("すべての画面サイズでカテゴリと説明が表示される", () => {
+			const { rerender } = render(
+				<ExpenseList
+					transactions={mockTransactions}
+					isLoading={false}
+					error={null}
+				/>,
+			);
+
+			// デスクトップサイズ（1024px）
+			global.innerWidth = 1024;
+			global.dispatchEvent(new Event("resize"));
+			rerender(
+				<ExpenseList
+					transactions={mockTransactions}
+					isLoading={false}
+					error={null}
+				/>,
+			);
+
+			// デスクトップではすべての列が表示される
+			expect(screen.getByText("カテゴリ")).toBeVisible();
+			expect(screen.getByText("説明")).toBeVisible();
+
+			// タブレットサイズ（768px）
+			global.innerWidth = 768;
+			global.dispatchEvent(new Event("resize"));
+			rerender(
+				<ExpenseList
+					transactions={mockTransactions}
+					isLoading={false}
+					error={null}
+				/>,
+			);
+
+			// タブレットでもカテゴリと説明が表示される
+			expect(screen.getByText("カテゴリ")).toBeVisible();
+			expect(screen.getByText("説明")).toBeVisible();
+
+			// モバイルサイズ（375px）
+			global.innerWidth = 375;
+			global.dispatchEvent(new Event("resize"));
+			rerender(
+				<ExpenseList
+					transactions={mockTransactions}
+					isLoading={false}
+					error={null}
+				/>,
+			);
+
+			// モバイルでもカテゴリと説明が表示される（Issue #325の要件）
+			expect(screen.getByText("カテゴリ")).toBeVisible();
+			expect(screen.getByText("説明")).toBeVisible();
+		});
+	});
+
 	describe("エッジケース", () => {
 		it("取引データのnull値でも安全に処理される", () => {
 			const transactionWithNulls = [

--- a/frontend/src/components/expenses/ExpenseList.tsx
+++ b/frontend/src/components/expenses/ExpenseList.tsx
@@ -37,25 +37,27 @@ const TransactionRow: FC<{
 
 	return (
 		<tr className="border-b border-gray-200 hover:bg-gray-50 transition-colors">
-			<td className="px-4 py-3 text-sm text-gray-900">
+			<td className="px-2 sm:px-4 py-3 text-xs sm:text-sm text-gray-900">
 				{formatDate(transaction.date)}
 			</td>
-			<td className={`px-4 py-3 text-sm font-medium ${getAmountColor()}`}>
+			<td
+				className={`px-2 sm:px-4 py-3 text-xs sm:text-sm font-medium ${getAmountColor()}`}
+			>
 				{formatCurrency(transaction.amount, true)}
 			</td>
-			<td className="px-4 py-3 text-sm text-gray-700 hidden md:table-cell">
+			<td className="px-2 sm:px-4 py-3 text-xs sm:text-sm text-gray-700 max-w-[80px] sm:max-w-none truncate">
 				{formatCategoryName(transaction.category)}
 			</td>
-			<td className="px-4 py-3 text-sm text-gray-700 hidden sm:table-cell">
+			<td className="px-2 sm:px-4 py-3 text-xs sm:text-sm text-gray-700 max-w-[120px] sm:max-w-none truncate">
 				{transaction.description || ""}
 			</td>
-			<td className="px-4 py-3 text-sm text-gray-700">
-				<div className="flex space-x-2">
+			<td className="px-2 sm:px-4 py-3 text-xs sm:text-sm text-gray-700">
+				<div className="flex space-x-1 sm:space-x-2">
 					{onEdit && (
 						<button
 							type="button"
 							onClick={() => onEdit(transaction)}
-							className="text-blue-600 hover:text-blue-800 transition-colors"
+							className="text-blue-600 hover:text-blue-800 transition-colors text-xs sm:text-sm"
 						>
 							編集
 						</button>
@@ -64,7 +66,7 @@ const TransactionRow: FC<{
 						<button
 							type="button"
 							onClick={() => onDelete(transaction.id)}
-							className="text-red-600 hover:text-red-800 transition-colors"
+							className="text-red-600 hover:text-red-800 transition-colors text-xs sm:text-sm"
 						>
 							削除
 						</button>
@@ -156,31 +158,32 @@ export const ExpenseList: FC<ExpenseListProps> = ({
 						<tr>
 							<th
 								scope="col"
-								className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+								className="px-2 sm:px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-tighter sm:tracking-wider"
 							>
 								日付
 							</th>
 							<th
 								scope="col"
-								className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+								className="px-2 sm:px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-tighter sm:tracking-wider"
 							>
 								金額
 							</th>
 							<th
 								scope="col"
-								className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell"
+								className="px-2 sm:px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-tighter sm:tracking-wider"
 							>
-								カテゴリ
+								<span className="sm:hidden">カテ</span>
+								<span className="hidden sm:inline">カテゴリ</span>
 							</th>
 							<th
 								scope="col"
-								className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider hidden sm:table-cell"
+								className="px-2 sm:px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-tighter sm:tracking-wider"
 							>
 								説明
 							</th>
 							<th
 								scope="col"
-								className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+								className="px-2 sm:px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-tighter sm:tracking-wider"
 							>
 								操作
 							</th>

--- a/frontend/src/components/expenses/ExpenseList.tsx
+++ b/frontend/src/components/expenses/ExpenseList.tsx
@@ -52,12 +52,12 @@ const TransactionRow: FC<{
 				{transaction.description || ""}
 			</td>
 			<td className="px-2 sm:px-4 py-3 text-xs sm:text-sm text-gray-700">
-				<div className="flex space-x-1 sm:space-x-2">
+				<div className="flex flex-col gap-1">
 					{onEdit && (
 						<button
 							type="button"
 							onClick={() => onEdit(transaction)}
-							className="text-blue-600 hover:text-blue-800 transition-colors text-xs sm:text-sm"
+							className="text-blue-600 hover:text-blue-800 transition-colors text-xs sm:text-sm whitespace-nowrap"
 						>
 							編集
 						</button>
@@ -66,7 +66,7 @@ const TransactionRow: FC<{
 						<button
 							type="button"
 							onClick={() => onDelete(transaction.id)}
-							className="text-red-600 hover:text-red-800 transition-colors text-xs sm:text-sm"
+							className="text-red-600 hover:text-red-800 transition-colors text-xs sm:text-sm whitespace-nowrap"
 						>
 							削除
 						</button>


### PR DESCRIPTION
## 概要

支出管理画面のモバイル表示を改善し、これまで非表示だったカテゴリと備考（説明）をモバイルでも表示するように変更しました。

## 変更内容

- ExpenseListコンポーネントのレスポンシブクラスを修正
- モバイルでもすべての列（日付、金額、カテゴリ、説明、操作）を表示
- モバイル向けの最適化:
  - フォントサイズを画面幅に応じて調整（text-xs sm:text-sm）
  - パディングを画面幅に応じて調整（px-2 sm:px-4）
  - カテゴリと備考の最大幅を設定し、長いテキストは省略表示（truncate）
  - モバイルでカテゴリを「カテ」と省略表示

## テスト

- ユニットテストを追加し、モバイル表示の動作を検証
- すべてのテストがパス済み
- `npm run check:fix` 実行済み

close #325

🤖 Generated with [Claude Code](https://claude.ai/code)