### PR TITLE
feat: issue-252 ローディング状態のUIを統一

### DIFF
--- a/e2e/tests/loading-states.spec.ts
+++ b/e2e/tests/loading-states.spec.ts
@@ -1,0 +1,124 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("ローディング状態の統一性", () => {
+  test("支出一覧のローディング状態が統一されたUIを使用している", async ({ page }) => {
+    // APIレスポンスを遅延させてローディング状態を確認
+    await page.route("**/api/transactions", async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      });
+    });
+
+    await page.goto("/expenses");
+
+    // 統一されたローディングコンポーネントが表示される
+    const loadingState = page.getByTestId("loading-state");
+    await expect(loadingState).toBeVisible();
+    
+    // スピナーが表示される
+    const spinner = loadingState.locator('[role="status"]');
+    await expect(spinner).toBeVisible();
+    await expect(spinner).toHaveAttribute("aria-live", "polite");
+    await expect(spinner).toHaveAttribute("aria-label", "読み込み中");
+    
+    // 統一されたメッセージが表示される
+    await expect(loadingState).toContainText("読み込み中...");
+  });
+
+  test("サブスクリプション一覧のローディング状態が統一されたUIを使用している", async ({ page }) => {
+    await page.route("**/api/subscriptions", async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      });
+    });
+
+    await page.goto("/subscriptions");
+
+    const loadingState = page.getByTestId("loading-state");
+    await expect(loadingState).toBeVisible();
+    
+    // 支出一覧と同じローディングUIが使用される
+    const spinner = loadingState.locator('[role="status"]');
+    await expect(spinner).toBeVisible();
+    await expect(loadingState).toContainText("読み込み中...");
+  });
+
+  test("統計情報のスケルトンローディングが統一されたUIを使用している", async ({ page }) => {
+    await page.route("**/api/transactions/stats**", async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          totalExpenses: 50000,
+          monthlyAverage: 25000,
+          categoryBreakdown: [],
+        }),
+      });
+    });
+
+    await page.goto("/expenses");
+
+    // スケルトンローディングが表示される
+    const skeleton = page.locator('[aria-busy="true"]').first();
+    await expect(skeleton).toBeVisible();
+    await expect(skeleton).toHaveAttribute("aria-label", "読み込み中");
+    
+    // アニメーションクラスが適用される
+    await expect(skeleton).toHaveClass(/animate-pulse/);
+  });
+
+  test("ボタンのローディング状態が統一されたUIを使用している", async ({ page }) => {
+    await page.goto("/expenses/new");
+
+    // フォーム送信時のローディング
+    await page.fill('input[name="amount"]', "1000");
+    await page.fill('textarea[name="description"]', "テスト支出");
+
+    // APIレスポンスを遅延させる
+    await page.route("**/api/transactions", async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({ id: "1", amount: 1000 }),
+      });
+    });
+
+    // 送信ボタンをクリック
+    const submitButton = page.getByRole("button", { name: /登録/ });
+    await submitButton.click();
+
+    // ボタン内にローディングスピナーが表示される
+    const buttonSpinner = submitButton.locator('[role="status"]');
+    await expect(buttonSpinner).toBeVisible();
+    await expect(submitButton).toBeDisabled();
+  });
+
+  test("異なるページ間でローディングUIの一貫性が保たれる", async ({ page }) => {
+    // 複数のAPIエンドポイントを遅延させる
+    await page.route("**/api/**", async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+      await route.continue();
+    });
+
+    // 支出ページでのローディング
+    await page.goto("/expenses");
+    const expenseLoading = page.getByTestId("loading-state").first();
+    const expenseSpinnerClasses = await expenseLoading.locator('[role="status"]').getAttribute("class");
+
+    // サブスクリプションページでのローディング
+    await page.goto("/subscriptions");
+    const subLoading = page.getByTestId("loading-state").first();
+    const subSpinnerClasses = await subLoading.locator('[role="status"]').getAttribute("class");
+
+    // 両ページで同じクラスが使用されている
+    expect(expenseSpinnerClasses).toBe(subSpinnerClasses);
+  });
+});

--- a/frontend/src/components/expenses/ExpenseList.tsx
+++ b/frontend/src/components/expenses/ExpenseList.tsx
@@ -16,6 +16,7 @@
 import type { FC } from "react";
 import type { Transaction } from "../../lib/api/types";
 import type { ExpenseListProps } from "../../types/expense";
+import { LoadingState } from "../ui";
 import {
 	formatCategoryName,
 	formatCurrency,
@@ -77,22 +78,6 @@ const TransactionRow: FC<{
 	);
 };
 
-/**
- * ローディング状態の表示コンポーネント
- */
-const LoadingState: FC = () => (
-	<tr>
-		<td colSpan={5} className="px-4 py-8 text-center text-gray-500">
-			<div className="flex items-center justify-center space-x-2">
-				<div
-					className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600"
-					data-testid="loading-spinner"
-				/>
-				<span>読み込み中...</span>
-			</div>
-		</td>
-	</tr>
-);
 
 /**
  * エラー状態の表示コンポーネント
@@ -190,7 +175,13 @@ export const ExpenseList: FC<ExpenseListProps> = ({
 						</tr>
 					</thead>
 					<tbody className="bg-white divide-y divide-gray-200">
-						{isLoading && <LoadingState />}
+						{isLoading && (
+							<tr>
+								<td colSpan={5} className="px-4 py-8">
+									<LoadingState />
+								</td>
+							</tr>
+						)}
 						{error && <ErrorState message={error} />}
 						{!isLoading && !error && sortedTransactions.length === 0 && (
 							<EmptyState />

--- a/frontend/src/components/expenses/ExpenseList.tsx
+++ b/frontend/src/components/expenses/ExpenseList.tsx
@@ -16,12 +16,12 @@
 import type { FC } from "react";
 import type { Transaction } from "../../lib/api/types";
 import type { ExpenseListProps } from "../../types/expense";
-import { LoadingState } from "../ui";
 import {
 	formatCategoryName,
 	formatCurrency,
 	formatDate,
 } from "../../utils/format";
+import { LoadingState } from "../ui";
 
 /**
  * 単一の取引行コンポーネント
@@ -77,7 +77,6 @@ const TransactionRow: FC<{
 		</tr>
 	);
 };
-
 
 /**
  * エラー状態の表示コンポーネント

--- a/frontend/src/components/expenses/ExpenseStats.tsx
+++ b/frontend/src/components/expenses/ExpenseStats.tsx
@@ -13,6 +13,7 @@
  */
 
 import React, { type FC } from "react";
+import { LoadingState, Skeleton } from "../ui";
 import { formatCurrency, formatPercentage } from "../../utils/format";
 
 // 現在のAPI仕様で利用可能な基本統計データ
@@ -75,24 +76,20 @@ const SkeletonLoader: FC = () => (
 	<div
 		className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
 		data-testid="stats-skeleton"
-		role="status"
-		aria-live="polite"
-		aria-label="統計データを読み込み中"
 	>
 		{[1, 2, 3].map((index) => (
 			<div
 				key={index}
-				className="bg-white rounded-lg shadow-sm p-6 animate-pulse"
+				className="bg-white rounded-lg shadow-sm p-6"
 			>
-				<div className="h-6 bg-gray-200 rounded w-3/4 mb-4" />
+				<Skeleton variant="text" width="75%" height={24} className="mb-4" />
 				<div className="space-y-3">
-					<div className="h-4 bg-gray-200 rounded w-full" />
-					<div className="h-4 bg-gray-200 rounded w-5/6" />
-					<div className="h-8 bg-gray-300 rounded w-1/2 mt-4" />
+					<Skeleton variant="text" width="100%" />
+					<Skeleton variant="text" width="83%" />
+					<Skeleton variant="rectangular" width="50%" height={32} className="mt-4" />
 				</div>
 			</div>
 		))}
-		<span className="sr-only">読み込み中...</span>
 	</div>
 );
 
@@ -100,14 +97,8 @@ const SkeletonLoader: FC = () => (
  * 従来のローディング表示（シンプルなスピナー）
  */
 const LoadingSpinner: FC = () => (
-	<div
-		className="flex flex-col items-center justify-center py-12"
-		data-testid="stats-loading"
-		role="status"
-		aria-live="polite"
-	>
-		<div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600" />
-		<p className="mt-4 text-gray-600">読み込み中...</p>
+	<div className="py-12">
+		<LoadingState size="lg" layout="block" testId="stats-loading" />
 	</div>
 );
 

--- a/frontend/src/components/expenses/ExpenseStats.tsx
+++ b/frontend/src/components/expenses/ExpenseStats.tsx
@@ -13,8 +13,8 @@
  */
 
 import React, { type FC } from "react";
-import { LoadingState, Skeleton } from "../ui";
 import { formatCurrency, formatPercentage } from "../../utils/format";
+import { LoadingState, Skeleton } from "../ui";
 
 // 現在のAPI仕様で利用可能な基本統計データ
 export interface BaseStatsData {
@@ -78,15 +78,17 @@ const SkeletonLoader: FC = () => (
 		data-testid="stats-skeleton"
 	>
 		{[1, 2, 3].map((index) => (
-			<div
-				key={index}
-				className="bg-white rounded-lg shadow-sm p-6"
-			>
+			<div key={index} className="bg-white rounded-lg shadow-sm p-6">
 				<Skeleton variant="text" width="75%" height={24} className="mb-4" />
 				<div className="space-y-3">
 					<Skeleton variant="text" width="100%" />
 					<Skeleton variant="text" width="83%" />
-					<Skeleton variant="rectangular" width="50%" height={32} className="mt-4" />
+					<Skeleton
+						variant="rectangular"
+						width="50%"
+						height={32}
+						className="mt-4"
+					/>
 				</div>
 			</div>
 		))}

--- a/frontend/src/components/subscriptions/SubscriptionList.tsx
+++ b/frontend/src/components/subscriptions/SubscriptionList.tsx
@@ -84,7 +84,6 @@ const SubscriptionRow: FC<{ subscription: Subscription }> = ({
 	);
 };
 
-
 /**
  * エラー状態の表示コンポーネント
  */

--- a/frontend/src/components/subscriptions/SubscriptionList.tsx
+++ b/frontend/src/components/subscriptions/SubscriptionList.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react";
 import type { Subscription, SubscriptionListProps } from "../../lib/api/types";
+import { LoadingState, Spinner } from "../ui";
 
 /**
  * サブスクリプション一覧コンポーネント
@@ -83,19 +84,6 @@ const SubscriptionRow: FC<{ subscription: Subscription }> = ({
 	);
 };
 
-/**
- * ローディング状態の表示コンポーネント
- */
-const LoadingState: FC = () => (
-	<tr>
-		<td colSpan={5} className="px-4 py-8 text-center text-gray-500">
-			<div className="flex items-center justify-center space-x-2">
-				<div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600" />
-				<span>読み込み中...</span>
-			</div>
-		</td>
-	</tr>
-);
 
 /**
  * エラー状態の表示コンポーネント
@@ -159,7 +147,7 @@ export const SubscriptionList: FC<SubscriptionListProps> = ({
 							className="inline-flex items-center px-3 py-2 border border-gray-300 shadow-sm text-sm leading-4 font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
 						>
 							{isLoading ? (
-								<div className="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-600 mr-2" />
+								<Spinner size="sm" color="secondary" className="mr-2" />
 							) : (
 								<span className="mr-2">🔄</span>
 							)}
@@ -207,7 +195,13 @@ export const SubscriptionList: FC<SubscriptionListProps> = ({
 						</tr>
 					</thead>
 					<tbody className="bg-white divide-y divide-gray-200">
-						{isLoading && <LoadingState />}
+						{isLoading && (
+							<tr>
+								<td colSpan={5} className="px-4 py-8">
+									<LoadingState />
+								</td>
+							</tr>
+						)}
 						{error && <ErrorState message={error} />}
 						{!isLoading && !error && subscriptions.length === 0 && (
 							<EmptyState />

--- a/frontend/src/components/ui/LoadingState.stories.tsx
+++ b/frontend/src/components/ui/LoadingState.stories.tsx
@@ -1,0 +1,136 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { LoadingState } from "./LoadingState";
+
+const meta: Meta<typeof LoadingState> = {
+  title: "UI/LoadingState",
+  component: LoadingState,
+  parameters: {
+    docs: {
+      description: {
+        component: "統一されたローディング状態表示コンポーネント。様々なレイアウトパターンを提供します。",
+      },
+    },
+  },
+  argTypes: {
+    message: {
+      control: "text",
+      description: "表示するメッセージ",
+    },
+    size: {
+      control: "radio",
+      options: ["sm", "md", "lg"],
+      description: "スピナーのサイズ",
+    },
+    layout: {
+      control: "radio",
+      options: ["inline", "block", "fullpage"],
+      description: "レイアウトパターン",
+    },
+    testId: {
+      control: "text",
+      description: "テスト用のdata-testid属性",
+    },
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Inline: Story = {
+  args: {
+    layout: "inline",
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-gray-100 p-4 rounded">
+        <span className="mr-2">何かのテキスト</span>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const Block: Story = {
+  args: {
+    layout: "block",
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-gray-100 p-4 rounded h-64">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const FullPage: Story = {
+  args: {
+    layout: "fullpage",
+  },
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [
+    (Story) => (
+      <div className="relative h-96">
+        <div className="p-4">
+          <h1 className="text-2xl font-bold mb-4">ページコンテンツ</h1>
+          <p>このコンテンツの上にローディングが表示されます。</p>
+        </div>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const CustomMessage: Story = {
+  args: {
+    message: "データを取得しています...",
+  },
+};
+
+export const LargeSize: Story = {
+  args: {
+    size: "lg",
+    message: "処理中です...",
+  },
+};
+
+export const InButton: Story = {
+  render: () => (
+    <button
+      type="button" 
+      className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-md disabled:opacity-50"
+      disabled
+    >
+      <LoadingState layout="inline" size="sm" message="送信中..." />
+    </button>
+  ),
+};
+
+export const InTable: Story = {
+  render: () => (
+    <table className="min-w-full divide-y divide-gray-200">
+      <thead className="bg-gray-50">
+        <tr>
+          <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+            項目
+          </th>
+          <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+            金額
+          </th>
+        </tr>
+      </thead>
+      <tbody className="bg-white divide-y divide-gray-200">
+        <tr>
+          <td colSpan={2} className="px-4 py-8">
+            <LoadingState />
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  ),
+};

--- a/frontend/src/components/ui/LoadingState.stories.tsx
+++ b/frontend/src/components/ui/LoadingState.stories.tsx
@@ -2,36 +2,37 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { LoadingState } from "./LoadingState";
 
 const meta: Meta<typeof LoadingState> = {
-  title: "UI/LoadingState",
-  component: LoadingState,
-  parameters: {
-    docs: {
-      description: {
-        component: "統一されたローディング状態表示コンポーネント。様々なレイアウトパターンを提供します。",
-      },
-    },
-  },
-  argTypes: {
-    message: {
-      control: "text",
-      description: "表示するメッセージ",
-    },
-    size: {
-      control: "radio",
-      options: ["sm", "md", "lg"],
-      description: "スピナーのサイズ",
-    },
-    layout: {
-      control: "radio",
-      options: ["inline", "block", "fullpage"],
-      description: "レイアウトパターン",
-    },
-    testId: {
-      control: "text",
-      description: "テスト用のdata-testid属性",
-    },
-  },
-  tags: ["autodocs"],
+	title: "UI/LoadingState",
+	component: LoadingState,
+	parameters: {
+		docs: {
+			description: {
+				component:
+					"統一されたローディング状態表示コンポーネント。様々なレイアウトパターンを提供します。",
+			},
+		},
+	},
+	argTypes: {
+		message: {
+			control: "text",
+			description: "表示するメッセージ",
+		},
+		size: {
+			control: "radio",
+			options: ["sm", "md", "lg"],
+			description: "スピナーのサイズ",
+		},
+		layout: {
+			control: "radio",
+			options: ["inline", "block", "fullpage"],
+			description: "レイアウトパターン",
+		},
+		testId: {
+			control: "text",
+			description: "テスト用のdata-testid属性",
+		},
+	},
+	tags: ["autodocs"],
 };
 
 export default meta;
@@ -40,97 +41,97 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {};
 
 export const Inline: Story = {
-  args: {
-    layout: "inline",
-  },
-  decorators: [
-    (Story) => (
-      <div className="bg-gray-100 p-4 rounded">
-        <span className="mr-2">何かのテキスト</span>
-        <Story />
-      </div>
-    ),
-  ],
+	args: {
+		layout: "inline",
+	},
+	decorators: [
+		(Story) => (
+			<div className="bg-gray-100 p-4 rounded">
+				<span className="mr-2">何かのテキスト</span>
+				<Story />
+			</div>
+		),
+	],
 };
 
 export const Block: Story = {
-  args: {
-    layout: "block",
-  },
-  decorators: [
-    (Story) => (
-      <div className="bg-gray-100 p-4 rounded h-64">
-        <Story />
-      </div>
-    ),
-  ],
+	args: {
+		layout: "block",
+	},
+	decorators: [
+		(Story) => (
+			<div className="bg-gray-100 p-4 rounded h-64">
+				<Story />
+			</div>
+		),
+	],
 };
 
 export const FullPage: Story = {
-  args: {
-    layout: "fullpage",
-  },
-  parameters: {
-    layout: "fullscreen",
-  },
-  decorators: [
-    (Story) => (
-      <div className="relative h-96">
-        <div className="p-4">
-          <h1 className="text-2xl font-bold mb-4">ページコンテンツ</h1>
-          <p>このコンテンツの上にローディングが表示されます。</p>
-        </div>
-        <Story />
-      </div>
-    ),
-  ],
+	args: {
+		layout: "fullpage",
+	},
+	parameters: {
+		layout: "fullscreen",
+	},
+	decorators: [
+		(Story) => (
+			<div className="relative h-96">
+				<div className="p-4">
+					<h1 className="text-2xl font-bold mb-4">ページコンテンツ</h1>
+					<p>このコンテンツの上にローディングが表示されます。</p>
+				</div>
+				<Story />
+			</div>
+		),
+	],
 };
 
 export const CustomMessage: Story = {
-  args: {
-    message: "データを取得しています...",
-  },
+	args: {
+		message: "データを取得しています...",
+	},
 };
 
 export const LargeSize: Story = {
-  args: {
-    size: "lg",
-    message: "処理中です...",
-  },
+	args: {
+		size: "lg",
+		message: "処理中です...",
+	},
 };
 
 export const InButton: Story = {
-  render: () => (
-    <button
-      type="button" 
-      className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-md disabled:opacity-50"
-      disabled
-    >
-      <LoadingState layout="inline" size="sm" message="送信中..." />
-    </button>
-  ),
+	render: () => (
+		<button
+			type="button"
+			className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-md disabled:opacity-50"
+			disabled
+		>
+			<LoadingState layout="inline" size="sm" message="送信中..." />
+		</button>
+	),
 };
 
 export const InTable: Story = {
-  render: () => (
-    <table className="min-w-full divide-y divide-gray-200">
-      <thead className="bg-gray-50">
-        <tr>
-          <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-            項目
-          </th>
-          <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
-            金額
-          </th>
-        </tr>
-      </thead>
-      <tbody className="bg-white divide-y divide-gray-200">
-        <tr>
-          <td colSpan={2} className="px-4 py-8">
-            <LoadingState />
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  ),
+	render: () => (
+		<table className="min-w-full divide-y divide-gray-200">
+			<thead className="bg-gray-50">
+				<tr>
+					<th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+						項目
+					</th>
+					<th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+						金額
+					</th>
+				</tr>
+			</thead>
+			<tbody className="bg-white divide-y divide-gray-200">
+				<tr>
+					<td colSpan={2} className="px-4 py-8">
+						<LoadingState />
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	),
 };

--- a/frontend/src/components/ui/LoadingState.test.tsx
+++ b/frontend/src/components/ui/LoadingState.test.tsx
@@ -3,65 +3,77 @@ import { describe, expect, it } from "vitest";
 import { LoadingState } from "./LoadingState";
 
 describe("LoadingState", () => {
-  // メッセージのテスト
-  it("デフォルトメッセージが表示される", () => {
-    render(<LoadingState />);
-    expect(screen.getByText("読み込み中...")).toBeInTheDocument();
-  });
+	// メッセージのテスト
+	it("デフォルトメッセージが表示される", () => {
+		render(<LoadingState />);
+		expect(screen.getByText("読み込み中...")).toBeInTheDocument();
+	});
 
-  it("カスタムメッセージを表示できる", () => {
-    render(<LoadingState message="データを取得しています" />);
-    expect(screen.getByText("データを取得しています")).toBeInTheDocument();
-  });
+	it("カスタムメッセージを表示できる", () => {
+		render(<LoadingState message="データを取得しています" />);
+		expect(screen.getByText("データを取得しています")).toBeInTheDocument();
+	});
 
-  // レイアウトバリエーションのテスト
-  it("inlineレイアウトの場合、適切なクラスが適用される", () => {
-    const { container } = render(<LoadingState layout="inline" />);
-    const wrapper = container.firstChild;
-    expect(wrapper).toHaveClass("inline-flex", "items-center", "space-x-2");
-  });
+	// レイアウトバリエーションのテスト
+	it("inlineレイアウトの場合、適切なクラスが適用される", () => {
+		const { container } = render(<LoadingState layout="inline" />);
+		const wrapper = container.firstChild;
+		expect(wrapper).toHaveClass("inline-flex", "items-center", "space-x-2");
+	});
 
-  it("blockレイアウトの場合、適切なクラスが適用される", () => {
-    const { container } = render(<LoadingState layout="block" />);
-    const wrapper = container.firstChild;
-    expect(wrapper).toHaveClass("flex", "items-center", "justify-center", "space-x-2", "py-8");
-  });
+	it("blockレイアウトの場合、適切なクラスが適用される", () => {
+		const { container } = render(<LoadingState layout="block" />);
+		const wrapper = container.firstChild;
+		expect(wrapper).toHaveClass(
+			"flex",
+			"items-center",
+			"justify-center",
+			"space-x-2",
+			"py-8",
+		);
+	});
 
-  it("fullpageレイアウトの場合、画面全体のスタイルが適用される", () => {
-    const { container } = render(<LoadingState layout="fullpage" />);
-    const wrapper = container.firstChild;
-    expect(wrapper).toHaveClass("fixed", "inset-0", "bg-white", "bg-opacity-75", "z-50");
-  });
+	it("fullpageレイアウトの場合、画面全体のスタイルが適用される", () => {
+		const { container } = render(<LoadingState layout="fullpage" />);
+		const wrapper = container.firstChild;
+		expect(wrapper).toHaveClass(
+			"fixed",
+			"inset-0",
+			"bg-white",
+			"bg-opacity-75",
+			"z-50",
+		);
+	});
 
-  // サイズの継承テスト
-  it("Spinnerコンポーネントにサイズが渡される", () => {
-    const { container } = render(<LoadingState size="lg" />);
-    const spinner = container.querySelector('[role="status"]');
-    expect(spinner).toHaveClass("h-8", "w-8");
-  });
+	// サイズの継承テスト
+	it("Spinnerコンポーネントにサイズが渡される", () => {
+		const { container } = render(<LoadingState size="lg" />);
+		const spinner = container.querySelector('[role="status"]');
+		expect(spinner).toHaveClass("h-8", "w-8");
+	});
 
-  // testIdのテスト
-  it("デフォルトのtestIdが設定される", () => {
-    render(<LoadingState />);
-    expect(screen.getByTestId("loading-state")).toBeInTheDocument();
-  });
+	// testIdのテスト
+	it("デフォルトのtestIdが設定される", () => {
+		render(<LoadingState />);
+		expect(screen.getByTestId("loading-state")).toBeInTheDocument();
+	});
 
-  it("カスタムtestIdを設定できる", () => {
-    render(<LoadingState testId="custom-loading" />);
-    expect(screen.getByTestId("custom-loading")).toBeInTheDocument();
-  });
+	it("カスタムtestIdを設定できる", () => {
+		render(<LoadingState testId="custom-loading" />);
+		expect(screen.getByTestId("custom-loading")).toBeInTheDocument();
+	});
 
-  // デフォルト値のテスト
-  it("デフォルトではblockレイアウトが適用される", () => {
-    const { container } = render(<LoadingState />);
-    const wrapper = container.firstChild;
-    expect(wrapper).toHaveClass("flex", "items-center", "justify-center");
-  });
+	// デフォルト値のテスト
+	it("デフォルトではblockレイアウトが適用される", () => {
+		const { container } = render(<LoadingState />);
+		const wrapper = container.firstChild;
+		expect(wrapper).toHaveClass("flex", "items-center", "justify-center");
+	});
 
-  // テキストカラーのテスト
-  it("テキストにグレーカラーが適用される", () => {
-    render(<LoadingState />);
-    const text = screen.getByText("読み込み中...");
-    expect(text).toHaveClass("text-gray-600");
-  });
+	// テキストカラーのテスト
+	it("テキストにグレーカラーが適用される", () => {
+		render(<LoadingState />);
+		const text = screen.getByText("読み込み中...");
+		expect(text).toHaveClass("text-gray-600");
+	});
 });

--- a/frontend/src/components/ui/LoadingState.test.tsx
+++ b/frontend/src/components/ui/LoadingState.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { LoadingState } from "./LoadingState";
+
+describe("LoadingState", () => {
+  // メッセージのテスト
+  it("デフォルトメッセージが表示される", () => {
+    render(<LoadingState />);
+    expect(screen.getByText("読み込み中...")).toBeInTheDocument();
+  });
+
+  it("カスタムメッセージを表示できる", () => {
+    render(<LoadingState message="データを取得しています" />);
+    expect(screen.getByText("データを取得しています")).toBeInTheDocument();
+  });
+
+  // レイアウトバリエーションのテスト
+  it("inlineレイアウトの場合、適切なクラスが適用される", () => {
+    const { container } = render(<LoadingState layout="inline" />);
+    const wrapper = container.firstChild;
+    expect(wrapper).toHaveClass("inline-flex", "items-center", "space-x-2");
+  });
+
+  it("blockレイアウトの場合、適切なクラスが適用される", () => {
+    const { container } = render(<LoadingState layout="block" />);
+    const wrapper = container.firstChild;
+    expect(wrapper).toHaveClass("flex", "items-center", "justify-center", "space-x-2", "py-8");
+  });
+
+  it("fullpageレイアウトの場合、画面全体のスタイルが適用される", () => {
+    const { container } = render(<LoadingState layout="fullpage" />);
+    const wrapper = container.firstChild;
+    expect(wrapper).toHaveClass("fixed", "inset-0", "bg-white", "bg-opacity-75", "z-50");
+  });
+
+  // サイズの継承テスト
+  it("Spinnerコンポーネントにサイズが渡される", () => {
+    const { container } = render(<LoadingState size="lg" />);
+    const spinner = container.querySelector('[role="status"]');
+    expect(spinner).toHaveClass("h-8", "w-8");
+  });
+
+  // testIdのテスト
+  it("デフォルトのtestIdが設定される", () => {
+    render(<LoadingState />);
+    expect(screen.getByTestId("loading-state")).toBeInTheDocument();
+  });
+
+  it("カスタムtestIdを設定できる", () => {
+    render(<LoadingState testId="custom-loading" />);
+    expect(screen.getByTestId("custom-loading")).toBeInTheDocument();
+  });
+
+  // デフォルト値のテスト
+  it("デフォルトではblockレイアウトが適用される", () => {
+    const { container } = render(<LoadingState />);
+    const wrapper = container.firstChild;
+    expect(wrapper).toHaveClass("flex", "items-center", "justify-center");
+  });
+
+  // テキストカラーのテスト
+  it("テキストにグレーカラーが適用される", () => {
+    render(<LoadingState />);
+    const text = screen.getByText("読み込み中...");
+    expect(text).toHaveClass("text-gray-600");
+  });
+});

--- a/frontend/src/components/ui/LoadingState.tsx
+++ b/frontend/src/components/ui/LoadingState.tsx
@@ -2,30 +2,31 @@ import type { FC } from "react";
 import { Spinner, type SpinnerProps } from "./Spinner";
 
 export interface LoadingStateProps {
-  message?: string;
-  size?: SpinnerProps["size"];
-  layout?: "inline" | "block" | "fullpage";
-  testId?: string;
+	message?: string;
+	size?: SpinnerProps["size"];
+	layout?: "inline" | "block" | "fullpage";
+	testId?: string;
 }
 
 const layoutClasses = {
-  inline: "inline-flex items-center space-x-2",
-  block: "flex items-center justify-center space-x-2 py-8",
-  fullpage: "fixed inset-0 bg-white bg-opacity-75 z-50 flex items-center justify-center space-x-2",
+	inline: "inline-flex items-center space-x-2",
+	block: "flex items-center justify-center space-x-2 py-8",
+	fullpage:
+		"fixed inset-0 bg-white bg-opacity-75 z-50 flex items-center justify-center space-x-2",
 } as const;
 
 export const LoadingState: FC<LoadingStateProps> = ({
-  message = "読み込み中...",
-  size = "sm",
-  layout = "block",
-  testId = "loading-state",
+	message = "読み込み中...",
+	size = "sm",
+	layout = "block",
+	testId = "loading-state",
 }) => {
-  const layoutClass = layoutClasses[layout];
+	const layoutClass = layoutClasses[layout];
 
-  return (
-    <div className={layoutClass} data-testid={testId}>
-      <Spinner size={size} />
-      <span className="text-gray-600">{message}</span>
-    </div>
-  );
+	return (
+		<div className={layoutClass} data-testid={testId}>
+			<Spinner size={size} />
+			<span className="text-gray-600">{message}</span>
+		</div>
+	);
 };

--- a/frontend/src/components/ui/LoadingState.tsx
+++ b/frontend/src/components/ui/LoadingState.tsx
@@ -1,0 +1,31 @@
+import type { FC } from "react";
+import { Spinner, type SpinnerProps } from "./Spinner";
+
+export interface LoadingStateProps {
+  message?: string;
+  size?: SpinnerProps["size"];
+  layout?: "inline" | "block" | "fullpage";
+  testId?: string;
+}
+
+const layoutClasses = {
+  inline: "inline-flex items-center space-x-2",
+  block: "flex items-center justify-center space-x-2 py-8",
+  fullpage: "fixed inset-0 bg-white bg-opacity-75 z-50 flex items-center justify-center space-x-2",
+} as const;
+
+export const LoadingState: FC<LoadingStateProps> = ({
+  message = "読み込み中...",
+  size = "sm",
+  layout = "block",
+  testId = "loading-state",
+}) => {
+  const layoutClass = layoutClasses[layout];
+
+  return (
+    <div className={layoutClass} data-testid={testId}>
+      <Spinner size={size} />
+      <span className="text-gray-600">{message}</span>
+    </div>
+  );
+};

--- a/frontend/src/components/ui/Skeleton.stories.tsx
+++ b/frontend/src/components/ui/Skeleton.stories.tsx
@@ -1,0 +1,147 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Skeleton } from "./Skeleton";
+
+const meta: Meta<typeof Skeleton> = {
+  title: "UI/Skeleton",
+  component: Skeleton,
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component: "コンテンツ読み込み中に表示するスケルトンローダー。様々な形状とパターンを提供します。",
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: "radio",
+      options: ["text", "rectangular", "circular"],
+      description: "スケルトンの形状",
+    },
+    width: {
+      control: "text",
+      description: "幅（数値またはCSS値）",
+    },
+    height: {
+      control: "text",
+      description: "高さ（数値またはCSS値）",
+    },
+    count: {
+      control: "number",
+      description: "複数行の場合の行数",
+    },
+    className: {
+      control: "text",
+      description: "追加のCSSクラス",
+    },
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    width: "100%",
+    height: 40,
+  },
+};
+
+export const Text: Story = {
+  args: {
+    variant: "text",
+    width: "100%",
+  },
+};
+
+export const Rectangular: Story = {
+  args: {
+    variant: "rectangular",
+    width: 200,
+    height: 100,
+  },
+};
+
+export const Circular: Story = {
+  args: {
+    variant: "circular",
+    width: 80,
+    height: 80,
+  },
+};
+
+export const MultipleLines: Story = {
+  args: {
+    variant: "text",
+    count: 3,
+    width: "100%",
+  },
+};
+
+export const Card: Story = {
+  render: () => (
+    <div className="bg-white rounded-lg shadow-sm p-6 max-w-md">
+      <div className="flex items-center mb-4">
+        <Skeleton variant="circular" width={48} height={48} />
+        <div className="ml-4 flex-1">
+          <Skeleton variant="text" width="60%" className="mb-2" />
+          <Skeleton variant="text" width="40%" />
+        </div>
+      </div>
+      <Skeleton variant="text" count={3} />
+      <div className="mt-4 flex space-x-2">
+        <Skeleton variant="rectangular" width={80} height={32} />
+        <Skeleton variant="rectangular" width={80} height={32} />
+      </div>
+    </div>
+  ),
+};
+
+export const Table: Story = {
+  render: () => (
+    <table className="min-w-full divide-y divide-gray-200">
+      <thead className="bg-gray-50">
+        <tr>
+          <th className="px-4 py-3 text-left">
+            <Skeleton variant="text" width="80%" />
+          </th>
+          <th className="px-4 py-3 text-left">
+            <Skeleton variant="text" width="60%" />
+          </th>
+          <th className="px-4 py-3 text-left">
+            <Skeleton variant="text" width="70%" />
+          </th>
+        </tr>
+      </thead>
+      <tbody className="bg-white divide-y divide-gray-200">
+        {[1, 2, 3].map((i) => (
+          <tr key={i}>
+            <td className="px-4 py-3">
+              <Skeleton variant="text" width="90%" />
+            </td>
+            <td className="px-4 py-3">
+              <Skeleton variant="text" width="70%" />
+            </td>
+            <td className="px-4 py-3">
+              <Skeleton variant="text" width="80%" />
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  ),
+};
+
+export const StatsCard: Story = {
+  render: () => (
+    <div className="bg-white rounded-lg shadow-sm p-6">
+      <Skeleton variant="text" width="75%" height={24} className="mb-4" />
+      <div className="space-y-3">
+        <Skeleton variant="text" width="100%" />
+        <Skeleton variant="text" width="83%" />
+        <Skeleton variant="rectangular" width="50%" height={32} className="mt-4" />
+      </div>
+    </div>
+  ),
+};

--- a/frontend/src/components/ui/Skeleton.stories.tsx
+++ b/frontend/src/components/ui/Skeleton.stories.tsx
@@ -2,146 +2,152 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Skeleton } from "./Skeleton";
 
 const meta: Meta<typeof Skeleton> = {
-  title: "UI/Skeleton",
-  component: Skeleton,
-  parameters: {
-    layout: "padded",
-    docs: {
-      description: {
-        component: "コンテンツ読み込み中に表示するスケルトンローダー。様々な形状とパターンを提供します。",
-      },
-    },
-  },
-  argTypes: {
-    variant: {
-      control: "radio",
-      options: ["text", "rectangular", "circular"],
-      description: "スケルトンの形状",
-    },
-    width: {
-      control: "text",
-      description: "幅（数値またはCSS値）",
-    },
-    height: {
-      control: "text",
-      description: "高さ（数値またはCSS値）",
-    },
-    count: {
-      control: "number",
-      description: "複数行の場合の行数",
-    },
-    className: {
-      control: "text",
-      description: "追加のCSSクラス",
-    },
-  },
-  tags: ["autodocs"],
+	title: "UI/Skeleton",
+	component: Skeleton,
+	parameters: {
+		layout: "padded",
+		docs: {
+			description: {
+				component:
+					"コンテンツ読み込み中に表示するスケルトンローダー。様々な形状とパターンを提供します。",
+			},
+		},
+	},
+	argTypes: {
+		variant: {
+			control: "radio",
+			options: ["text", "rectangular", "circular"],
+			description: "スケルトンの形状",
+		},
+		width: {
+			control: "text",
+			description: "幅（数値またはCSS値）",
+		},
+		height: {
+			control: "text",
+			description: "高さ（数値またはCSS値）",
+		},
+		count: {
+			control: "number",
+			description: "複数行の場合の行数",
+		},
+		className: {
+			control: "text",
+			description: "追加のCSSクラス",
+		},
+	},
+	tags: ["autodocs"],
 };
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  args: {
-    width: "100%",
-    height: 40,
-  },
+	args: {
+		width: "100%",
+		height: 40,
+	},
 };
 
 export const Text: Story = {
-  args: {
-    variant: "text",
-    width: "100%",
-  },
+	args: {
+		variant: "text",
+		width: "100%",
+	},
 };
 
 export const Rectangular: Story = {
-  args: {
-    variant: "rectangular",
-    width: 200,
-    height: 100,
-  },
+	args: {
+		variant: "rectangular",
+		width: 200,
+		height: 100,
+	},
 };
 
 export const Circular: Story = {
-  args: {
-    variant: "circular",
-    width: 80,
-    height: 80,
-  },
+	args: {
+		variant: "circular",
+		width: 80,
+		height: 80,
+	},
 };
 
 export const MultipleLines: Story = {
-  args: {
-    variant: "text",
-    count: 3,
-    width: "100%",
-  },
+	args: {
+		variant: "text",
+		count: 3,
+		width: "100%",
+	},
 };
 
 export const Card: Story = {
-  render: () => (
-    <div className="bg-white rounded-lg shadow-sm p-6 max-w-md">
-      <div className="flex items-center mb-4">
-        <Skeleton variant="circular" width={48} height={48} />
-        <div className="ml-4 flex-1">
-          <Skeleton variant="text" width="60%" className="mb-2" />
-          <Skeleton variant="text" width="40%" />
-        </div>
-      </div>
-      <Skeleton variant="text" count={3} />
-      <div className="mt-4 flex space-x-2">
-        <Skeleton variant="rectangular" width={80} height={32} />
-        <Skeleton variant="rectangular" width={80} height={32} />
-      </div>
-    </div>
-  ),
+	render: () => (
+		<div className="bg-white rounded-lg shadow-sm p-6 max-w-md">
+			<div className="flex items-center mb-4">
+				<Skeleton variant="circular" width={48} height={48} />
+				<div className="ml-4 flex-1">
+					<Skeleton variant="text" width="60%" className="mb-2" />
+					<Skeleton variant="text" width="40%" />
+				</div>
+			</div>
+			<Skeleton variant="text" count={3} />
+			<div className="mt-4 flex space-x-2">
+				<Skeleton variant="rectangular" width={80} height={32} />
+				<Skeleton variant="rectangular" width={80} height={32} />
+			</div>
+		</div>
+	),
 };
 
 export const Table: Story = {
-  render: () => (
-    <table className="min-w-full divide-y divide-gray-200">
-      <thead className="bg-gray-50">
-        <tr>
-          <th className="px-4 py-3 text-left">
-            <Skeleton variant="text" width="80%" />
-          </th>
-          <th className="px-4 py-3 text-left">
-            <Skeleton variant="text" width="60%" />
-          </th>
-          <th className="px-4 py-3 text-left">
-            <Skeleton variant="text" width="70%" />
-          </th>
-        </tr>
-      </thead>
-      <tbody className="bg-white divide-y divide-gray-200">
-        {[1, 2, 3].map((i) => (
-          <tr key={i}>
-            <td className="px-4 py-3">
-              <Skeleton variant="text" width="90%" />
-            </td>
-            <td className="px-4 py-3">
-              <Skeleton variant="text" width="70%" />
-            </td>
-            <td className="px-4 py-3">
-              <Skeleton variant="text" width="80%" />
-            </td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  ),
+	render: () => (
+		<table className="min-w-full divide-y divide-gray-200">
+			<thead className="bg-gray-50">
+				<tr>
+					<th className="px-4 py-3 text-left">
+						<Skeleton variant="text" width="80%" />
+					</th>
+					<th className="px-4 py-3 text-left">
+						<Skeleton variant="text" width="60%" />
+					</th>
+					<th className="px-4 py-3 text-left">
+						<Skeleton variant="text" width="70%" />
+					</th>
+				</tr>
+			</thead>
+			<tbody className="bg-white divide-y divide-gray-200">
+				{[1, 2, 3].map((i) => (
+					<tr key={i}>
+						<td className="px-4 py-3">
+							<Skeleton variant="text" width="90%" />
+						</td>
+						<td className="px-4 py-3">
+							<Skeleton variant="text" width="70%" />
+						</td>
+						<td className="px-4 py-3">
+							<Skeleton variant="text" width="80%" />
+						</td>
+					</tr>
+				))}
+			</tbody>
+		</table>
+	),
 };
 
 export const StatsCard: Story = {
-  render: () => (
-    <div className="bg-white rounded-lg shadow-sm p-6">
-      <Skeleton variant="text" width="75%" height={24} className="mb-4" />
-      <div className="space-y-3">
-        <Skeleton variant="text" width="100%" />
-        <Skeleton variant="text" width="83%" />
-        <Skeleton variant="rectangular" width="50%" height={32} className="mt-4" />
-      </div>
-    </div>
-  ),
+	render: () => (
+		<div className="bg-white rounded-lg shadow-sm p-6">
+			<Skeleton variant="text" width="75%" height={24} className="mb-4" />
+			<div className="space-y-3">
+				<Skeleton variant="text" width="100%" />
+				<Skeleton variant="text" width="83%" />
+				<Skeleton
+					variant="rectangular"
+					width="50%"
+					height={32}
+					className="mt-4"
+				/>
+			</div>
+		</div>
+	),
 };

--- a/frontend/src/components/ui/Skeleton.test.tsx
+++ b/frontend/src/components/ui/Skeleton.test.tsx
@@ -3,84 +3,87 @@ import { describe, expect, it } from "vitest";
 import { Skeleton } from "./Skeleton";
 
 describe("Skeleton", () => {
-  // バリアントのテスト
-  it("textバリアントの場合、適切な高さとボーダー半径が適用される", () => {
-    const { container } = render(<Skeleton variant="text" />);
-    const skeleton = container.firstChild;
-    expect(skeleton).toHaveClass("h-4", "rounded");
-  });
+	// バリアントのテスト
+	it("textバリアントの場合、適切な高さとボーダー半径が適用される", () => {
+		const { container } = render(<Skeleton variant="text" />);
+		const skeleton = container.firstChild;
+		expect(skeleton).toHaveClass("h-4", "rounded");
+	});
 
-  it("rectangularバリアントの場合、適切なボーダー半径が適用される", () => {
-    const { container } = render(<Skeleton variant="rectangular" />);
-    const skeleton = container.firstChild;
-    expect(skeleton).toHaveClass("rounded-md");
-  });
+	it("rectangularバリアントの場合、適切なボーダー半径が適用される", () => {
+		const { container } = render(<Skeleton variant="rectangular" />);
+		const skeleton = container.firstChild;
+		expect(skeleton).toHaveClass("rounded-md");
+	});
 
-  it("circularバリアントの場合、円形になる", () => {
-    const { container } = render(<Skeleton variant="circular" />);
-    const skeleton = container.firstChild;
-    expect(skeleton).toHaveClass("rounded-full");
-  });
+	it("circularバリアントの場合、円形になる", () => {
+		const { container } = render(<Skeleton variant="circular" />);
+		const skeleton = container.firstChild;
+		expect(skeleton).toHaveClass("rounded-full");
+	});
 
-  // サイズのテスト
-  it("カスタム幅を設定できる", () => {
-    const { container } = render(<Skeleton width={200} />);
-    const skeleton = container.firstChild;
-    expect(skeleton).toHaveStyle({ width: "200px" });
-  });
+	// サイズのテスト
+	it("カスタム幅を設定できる", () => {
+		const { container } = render(<Skeleton width={200} />);
+		const skeleton = container.firstChild;
+		expect(skeleton).toHaveStyle({ width: "200px" });
+	});
 
-  it("カスタム高さを設定できる", () => {
-    const { container } = render(<Skeleton height={50} />);
-    const skeleton = container.firstChild;
-    expect(skeleton).toHaveStyle({ height: "50px" });
-  });
+	it("カスタム高さを設定できる", () => {
+		const { container } = render(<Skeleton height={50} />);
+		const skeleton = container.firstChild;
+		expect(skeleton).toHaveStyle({ height: "50px" });
+	});
 
-  it("文字列で幅を設定できる", () => {
-    const { container } = render(<Skeleton width="100%" />);
-    const skeleton = container.firstChild;
-    expect(skeleton).toHaveStyle({ width: "100%" });
-  });
+	it("文字列で幅を設定できる", () => {
+		const { container } = render(<Skeleton width="100%" />);
+		const skeleton = container.firstChild;
+		expect(skeleton).toHaveStyle({ width: "100%" });
+	});
 
-  // 複数行のテスト
-  it("countを指定すると複数のスケルトン要素が作成される", () => {
-    const { container } = render(<Skeleton variant="text" count={3} />);
-    const skeletons = container.querySelectorAll(".animate-pulse");
-    expect(skeletons).toHaveLength(3);
-  });
+	// 複数行のテスト
+	it("countを指定すると複数のスケルトン要素が作成される", () => {
+		const { container } = render(<Skeleton variant="text" count={3} />);
+		const skeletons = container.querySelectorAll(".animate-pulse");
+		expect(skeletons).toHaveLength(3);
+	});
 
-  it("複数行の場合、最後の行は幅が80%になる", () => {
-    const { container } = render(<Skeleton variant="text" count={3} />);
-    const skeletons = container.querySelectorAll(".animate-pulse");
-    const lastSkeleton = skeletons[skeletons.length - 1];
-    expect(lastSkeleton).toHaveClass("w-4/5");
-  });
+	it("複数行の場合、最後の行は幅が80%になる", () => {
+		const { container } = render(<Skeleton variant="text" count={3} />);
+		const skeletons = container.querySelectorAll(".animate-pulse");
+		const lastSkeleton = skeletons[skeletons.length - 1];
+		expect(lastSkeleton).toHaveClass("w-4/5");
+	});
 
-  // デフォルト値のテスト
-  it("デフォルトではrectangularバリアントが適用される", () => {
-    const { container } = render(<Skeleton />);
-    const skeleton = container.firstChild;
-    expect(skeleton).toHaveClass("rounded-md");
-  });
+	// デフォルト値のテスト
+	it("デフォルトではrectangularバリアントが適用される", () => {
+		const { container } = render(<Skeleton />);
+		const skeleton = container.firstChild;
+		expect(skeleton).toHaveClass("rounded-md");
+	});
 
-  // 共通スタイルのテスト
-  it("すべてのバリアントにアニメーションとベースクラスが適用される", () => {
-    const { container } = render(<Skeleton />);
-    const skeleton = container.firstChild;
-    expect(skeleton).toHaveClass("animate-pulse", "bg-gray-200");
-  });
+	// 共通スタイルのテスト
+	it("すべてのバリアントにアニメーションとベースクラスが適用される", () => {
+		const { container } = render(<Skeleton />);
+		const skeleton = container.firstChild;
+		expect(skeleton).toHaveClass("animate-pulse", "bg-gray-200");
+	});
 
-  // カスタムクラスのテスト
-  it("カスタムクラスを追加できる", () => {
-    const { container } = render(<Skeleton className="custom-skeleton" />);
-    const skeleton = container.firstChild;
-    expect(skeleton).toHaveClass("custom-skeleton");
-  });
+	// カスタムクラスのテスト
+	it("カスタムクラスを追加できる", () => {
+		const { container } = render(<Skeleton className="custom-skeleton" />);
+		const skeleton = container.firstChild;
+		expect(skeleton).toHaveClass("custom-skeleton");
+	});
 
-  // アクセシビリティのテスト
-  it("適切なaria属性が設定される", () => {
-    const { container } = render(<Skeleton />);
-    const skeleton = container.firstChild;
-    expect(skeleton).toHaveAttribute("aria-busy", "true");
-    expect(skeleton).toHaveAttribute("aria-label", "読み込み中");
-  });
+	// アクセシビリティのテスト
+	it("適切なaria属性が設定される", () => {
+		const { container } = render(<Skeleton />);
+		const skeleton = container.firstChild;
+		expect(skeleton).toHaveAttribute("aria-busy", "true");
+		expect(skeleton).toHaveAttribute("role", "status");
+		// sr-onlyテキストが含まれていることを確認
+		const srOnlyText = (skeleton as HTMLElement)?.querySelector(".sr-only");
+		expect(srOnlyText).toHaveTextContent("読み込み中");
+	});
 });

--- a/frontend/src/components/ui/Skeleton.test.tsx
+++ b/frontend/src/components/ui/Skeleton.test.tsx
@@ -1,0 +1,86 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Skeleton } from "./Skeleton";
+
+describe("Skeleton", () => {
+  // バリアントのテスト
+  it("textバリアントの場合、適切な高さとボーダー半径が適用される", () => {
+    const { container } = render(<Skeleton variant="text" />);
+    const skeleton = container.firstChild;
+    expect(skeleton).toHaveClass("h-4", "rounded");
+  });
+
+  it("rectangularバリアントの場合、適切なボーダー半径が適用される", () => {
+    const { container } = render(<Skeleton variant="rectangular" />);
+    const skeleton = container.firstChild;
+    expect(skeleton).toHaveClass("rounded-md");
+  });
+
+  it("circularバリアントの場合、円形になる", () => {
+    const { container } = render(<Skeleton variant="circular" />);
+    const skeleton = container.firstChild;
+    expect(skeleton).toHaveClass("rounded-full");
+  });
+
+  // サイズのテスト
+  it("カスタム幅を設定できる", () => {
+    const { container } = render(<Skeleton width={200} />);
+    const skeleton = container.firstChild;
+    expect(skeleton).toHaveStyle({ width: "200px" });
+  });
+
+  it("カスタム高さを設定できる", () => {
+    const { container } = render(<Skeleton height={50} />);
+    const skeleton = container.firstChild;
+    expect(skeleton).toHaveStyle({ height: "50px" });
+  });
+
+  it("文字列で幅を設定できる", () => {
+    const { container } = render(<Skeleton width="100%" />);
+    const skeleton = container.firstChild;
+    expect(skeleton).toHaveStyle({ width: "100%" });
+  });
+
+  // 複数行のテスト
+  it("countを指定すると複数のスケルトン要素が作成される", () => {
+    const { container } = render(<Skeleton variant="text" count={3} />);
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons).toHaveLength(3);
+  });
+
+  it("複数行の場合、最後の行は幅が80%になる", () => {
+    const { container } = render(<Skeleton variant="text" count={3} />);
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    const lastSkeleton = skeletons[skeletons.length - 1];
+    expect(lastSkeleton).toHaveClass("w-4/5");
+  });
+
+  // デフォルト値のテスト
+  it("デフォルトではrectangularバリアントが適用される", () => {
+    const { container } = render(<Skeleton />);
+    const skeleton = container.firstChild;
+    expect(skeleton).toHaveClass("rounded-md");
+  });
+
+  // 共通スタイルのテスト
+  it("すべてのバリアントにアニメーションとベースクラスが適用される", () => {
+    const { container } = render(<Skeleton />);
+    const skeleton = container.firstChild;
+    expect(skeleton).toHaveClass("animate-pulse", "bg-gray-200");
+  });
+
+  // カスタムクラスのテスト
+  it("カスタムクラスを追加できる", () => {
+    const { container } = render(<Skeleton className="custom-skeleton" />);
+    const skeleton = container.firstChild;
+    expect(skeleton).toHaveClass("custom-skeleton");
+  });
+
+  // アクセシビリティのテスト
+  it("適切なaria属性が設定される", () => {
+    const { container } = render(<Skeleton />);
+    const skeleton = container.firstChild;
+    expect(skeleton).toHaveAttribute("aria-busy", "true");
+    expect(skeleton).toHaveAttribute("aria-label", "読み込み中");
+  });
+});

--- a/frontend/src/components/ui/Skeleton.tsx
+++ b/frontend/src/components/ui/Skeleton.tsx
@@ -1,0 +1,60 @@
+import type { CSSProperties, FC } from "react";
+
+export interface SkeletonProps {
+  variant?: "text" | "rectangular" | "circular";
+  width?: string | number;
+  height?: string | number;
+  className?: string;
+  count?: number;
+}
+
+const variantClasses = {
+  text: "h-4 rounded",
+  rectangular: "rounded-md",
+  circular: "rounded-full",
+} as const;
+
+export const Skeleton: FC<SkeletonProps> = ({
+  variant = "rectangular",
+  width,
+  height,
+  className = "",
+  count = 1,
+}) => {
+  const variantClass = variantClasses[variant];
+
+  const style: CSSProperties = {};
+  if (width) {
+    style.width = typeof width === "number" ? `${width}px` : width;
+  }
+  if (height) {
+    style.height = typeof height === "number" ? `${height}px` : height;
+  }
+
+  if (count > 1) {
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: count }).map((_, index) => (
+          <div
+            key={index}
+            className={`animate-pulse bg-gray-200 ${variantClass} ${
+              index === count - 1 ? "w-4/5" : ""
+            } ${className}`}
+            style={style}
+            aria-busy="true"
+            aria-label="読み込み中"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`animate-pulse bg-gray-200 ${variantClass} ${className}`}
+      style={style}
+      aria-busy="true"
+      aria-label="読み込み中"
+    />
+  );
+};

--- a/frontend/src/components/ui/Skeleton.tsx
+++ b/frontend/src/components/ui/Skeleton.tsx
@@ -1,60 +1,65 @@
 import type { CSSProperties, FC } from "react";
 
 export interface SkeletonProps {
-  variant?: "text" | "rectangular" | "circular";
-  width?: string | number;
-  height?: string | number;
-  className?: string;
-  count?: number;
+	variant?: "text" | "rectangular" | "circular";
+	width?: string | number;
+	height?: string | number;
+	className?: string;
+	count?: number;
 }
 
 const variantClasses = {
-  text: "h-4 rounded",
-  rectangular: "rounded-md",
-  circular: "rounded-full",
+	text: "h-4 rounded",
+	rectangular: "rounded-md",
+	circular: "rounded-full",
 } as const;
 
 export const Skeleton: FC<SkeletonProps> = ({
-  variant = "rectangular",
-  width,
-  height,
-  className = "",
-  count = 1,
+	variant = "rectangular",
+	width,
+	height,
+	className = "",
+	count = 1,
 }) => {
-  const variantClass = variantClasses[variant];
+	const variantClass = variantClasses[variant];
 
-  const style: CSSProperties = {};
-  if (width) {
-    style.width = typeof width === "number" ? `${width}px` : width;
-  }
-  if (height) {
-    style.height = typeof height === "number" ? `${height}px` : height;
-  }
+	const style: CSSProperties = {};
+	if (width) {
+		style.width = typeof width === "number" ? `${width}px` : width;
+	}
+	if (height) {
+		style.height = typeof height === "number" ? `${height}px` : height;
+	}
 
-  if (count > 1) {
-    return (
-      <div className="space-y-2">
-        {Array.from({ length: count }).map((_, index) => (
-          <div
-            key={index}
-            className={`animate-pulse bg-gray-200 ${variantClass} ${
-              index === count - 1 ? "w-4/5" : ""
-            } ${className}`}
-            style={style}
-            aria-busy="true"
-            aria-label="読み込み中"
-          />
-        ))}
-      </div>
-    );
-  }
+	if (count > 1) {
+		return (
+			<div className="space-y-2">
+				{Array.from({ length: count }).map((_, index) => (
+					<div
+						// biome-ignore lint/suspicious/noArrayIndexKey: countは固定値であり、配列の順序は変わらない
+						key={`skeleton-${index}`}
+						className={`animate-pulse bg-gray-200 ${variantClass} ${
+							index === count - 1 ? "w-4/5" : ""
+						} ${className}`}
+						style={style}
+						aria-busy="true"
+						role="status"
+					>
+						<span className="sr-only">読み込み中</span>
+					</div>
+				))}
+			</div>
+		);
+	}
 
-  return (
-    <div
-      className={`animate-pulse bg-gray-200 ${variantClass} ${className}`}
-      style={style}
-      aria-busy="true"
-      aria-label="読み込み中"
-    />
-  );
+	return (
+		<div
+			className={`animate-pulse bg-gray-200 ${variantClass} ${className}`}
+			style={style}
+			aria-busy="true"
+			role="status"
+		>
+			<span className="sr-only">読み込み中</span>
+		</div>
+	);
 };

--- a/frontend/src/components/ui/Spinner.stories.tsx
+++ b/frontend/src/components/ui/Spinner.stories.tsx
@@ -2,33 +2,34 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Spinner } from "./Spinner";
 
 const meta: Meta<typeof Spinner> = {
-  title: "UI/Spinner",
-  component: Spinner,
-  parameters: {
-    layout: "centered",
-    docs: {
-      description: {
-        component: "統一されたローディングスピナーコンポーネント。サイズとカラーのバリエーションを提供します。",
-      },
-    },
-  },
-  argTypes: {
-    size: {
-      control: "radio",
-      options: ["sm", "md", "lg"],
-      description: "スピナーのサイズ",
-    },
-    color: {
-      control: "radio", 
-      options: ["primary", "secondary"],
-      description: "スピナーの色",
-    },
-    className: {
-      control: "text",
-      description: "追加のCSSクラス",
-    },
-  },
-  tags: ["autodocs"],
+	title: "UI/Spinner",
+	component: Spinner,
+	parameters: {
+		layout: "centered",
+		docs: {
+			description: {
+				component:
+					"統一されたローディングスピナーコンポーネント。サイズとカラーのバリエーションを提供します。",
+			},
+		},
+	},
+	argTypes: {
+		size: {
+			control: "radio",
+			options: ["sm", "md", "lg"],
+			description: "スピナーのサイズ",
+		},
+		color: {
+			control: "radio",
+			options: ["primary", "secondary"],
+			description: "スピナーの色",
+		},
+		className: {
+			control: "text",
+			description: "追加のCSSクラス",
+		},
+	},
+	tags: ["autodocs"],
 };
 
 export default meta;
@@ -37,69 +38,69 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {};
 
 export const Small: Story = {
-  args: {
-    size: "sm",
-  },
+	args: {
+		size: "sm",
+	},
 };
 
 export const Medium: Story = {
-  args: {
-    size: "md",
-  },
+	args: {
+		size: "md",
+	},
 };
 
 export const Large: Story = {
-  args: {
-    size: "lg",
-  },
+	args: {
+		size: "lg",
+	},
 };
 
 export const Primary: Story = {
-  args: {
-    color: "primary",
-  },
+	args: {
+		color: "primary",
+	},
 };
 
 export const Secondary: Story = {
-  args: {
-    color: "secondary",
-  },
+	args: {
+		color: "secondary",
+	},
 };
 
 export const AllVariations: Story = {
-  render: () => (
-    <div className="space-y-8">
-      <div>
-        <h3 className="text-lg font-semibold mb-4">サイズバリエーション</h3>
-        <div className="flex items-center space-x-8">
-          <div className="text-center">
-            <Spinner size="sm" />
-            <p className="mt-2 text-sm text-gray-600">Small</p>
-          </div>
-          <div className="text-center">
-            <Spinner size="md" />
-            <p className="mt-2 text-sm text-gray-600">Medium</p>
-          </div>
-          <div className="text-center">
-            <Spinner size="lg" />
-            <p className="mt-2 text-sm text-gray-600">Large</p>
-          </div>
-        </div>
-      </div>
-      
-      <div>
-        <h3 className="text-lg font-semibold mb-4">カラーバリエーション</h3>
-        <div className="flex items-center space-x-8">
-          <div className="text-center">
-            <Spinner color="primary" size="md" />
-            <p className="mt-2 text-sm text-gray-600">Primary</p>
-          </div>
-          <div className="text-center">
-            <Spinner color="secondary" size="md" />
-            <p className="mt-2 text-sm text-gray-600">Secondary</p>
-          </div>
-        </div>
-      </div>
-    </div>
-  ),
+	render: () => (
+		<div className="space-y-8">
+			<div>
+				<h3 className="text-lg font-semibold mb-4">サイズバリエーション</h3>
+				<div className="flex items-center space-x-8">
+					<div className="text-center">
+						<Spinner size="sm" />
+						<p className="mt-2 text-sm text-gray-600">Small</p>
+					</div>
+					<div className="text-center">
+						<Spinner size="md" />
+						<p className="mt-2 text-sm text-gray-600">Medium</p>
+					</div>
+					<div className="text-center">
+						<Spinner size="lg" />
+						<p className="mt-2 text-sm text-gray-600">Large</p>
+					</div>
+				</div>
+			</div>
+
+			<div>
+				<h3 className="text-lg font-semibold mb-4">カラーバリエーション</h3>
+				<div className="flex items-center space-x-8">
+					<div className="text-center">
+						<Spinner color="primary" size="md" />
+						<p className="mt-2 text-sm text-gray-600">Primary</p>
+					</div>
+					<div className="text-center">
+						<Spinner color="secondary" size="md" />
+						<p className="mt-2 text-sm text-gray-600">Secondary</p>
+					</div>
+				</div>
+			</div>
+		</div>
+	),
 };

--- a/frontend/src/components/ui/Spinner.stories.tsx
+++ b/frontend/src/components/ui/Spinner.stories.tsx
@@ -1,0 +1,105 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Spinner } from "./Spinner";
+
+const meta: Meta<typeof Spinner> = {
+  title: "UI/Spinner",
+  component: Spinner,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: "統一されたローディングスピナーコンポーネント。サイズとカラーのバリエーションを提供します。",
+      },
+    },
+  },
+  argTypes: {
+    size: {
+      control: "radio",
+      options: ["sm", "md", "lg"],
+      description: "スピナーのサイズ",
+    },
+    color: {
+      control: "radio", 
+      options: ["primary", "secondary"],
+      description: "スピナーの色",
+    },
+    className: {
+      control: "text",
+      description: "追加のCSSクラス",
+    },
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Small: Story = {
+  args: {
+    size: "sm",
+  },
+};
+
+export const Medium: Story = {
+  args: {
+    size: "md",
+  },
+};
+
+export const Large: Story = {
+  args: {
+    size: "lg",
+  },
+};
+
+export const Primary: Story = {
+  args: {
+    color: "primary",
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    color: "secondary",
+  },
+};
+
+export const AllVariations: Story = {
+  render: () => (
+    <div className="space-y-8">
+      <div>
+        <h3 className="text-lg font-semibold mb-4">サイズバリエーション</h3>
+        <div className="flex items-center space-x-8">
+          <div className="text-center">
+            <Spinner size="sm" />
+            <p className="mt-2 text-sm text-gray-600">Small</p>
+          </div>
+          <div className="text-center">
+            <Spinner size="md" />
+            <p className="mt-2 text-sm text-gray-600">Medium</p>
+          </div>
+          <div className="text-center">
+            <Spinner size="lg" />
+            <p className="mt-2 text-sm text-gray-600">Large</p>
+          </div>
+        </div>
+      </div>
+      
+      <div>
+        <h3 className="text-lg font-semibold mb-4">カラーバリエーション</h3>
+        <div className="flex items-center space-x-8">
+          <div className="text-center">
+            <Spinner color="primary" size="md" />
+            <p className="mt-2 text-sm text-gray-600">Primary</p>
+          </div>
+          <div className="text-center">
+            <Spinner color="secondary" size="md" />
+            <p className="mt-2 text-sm text-gray-600">Secondary</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/frontend/src/components/ui/Spinner.test.tsx
+++ b/frontend/src/components/ui/Spinner.test.tsx
@@ -1,0 +1,66 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Spinner } from "./Spinner";
+
+describe("Spinner", () => {
+  // サイズバリエーションのテスト
+  it("smサイズの場合、h-4 w-4クラスが適用される", () => {
+    const { container } = render(<Spinner size="sm" />);
+    const spinner = container.querySelector('[role="status"]');
+    expect(spinner).toHaveClass("h-4", "w-4");
+  });
+
+  it("mdサイズの場合、h-6 w-6クラスが適用される", () => {
+    const { container } = render(<Spinner size="md" />);
+    const spinner = container.querySelector('[role="status"]');
+    expect(spinner).toHaveClass("h-6", "w-6");
+  });
+
+  it("lgサイズの場合、h-8 w-8クラスが適用される", () => {
+    const { container } = render(<Spinner size="lg" />);
+    const spinner = container.querySelector('[role="status"]');
+    expect(spinner).toHaveClass("h-8", "w-8");
+  });
+
+  // カラーバリエーションのテスト
+  it("primaryカラーの場合、border-blue-600クラスが適用される", () => {
+    const { container } = render(<Spinner color="primary" />);
+    const spinner = container.querySelector('[role="status"]');
+    expect(spinner).toHaveClass("border-blue-600");
+  });
+
+  it("secondaryカラーの場合、border-gray-600クラスが適用される", () => {
+    const { container } = render(<Spinner color="secondary" />);
+    const spinner = container.querySelector('[role="status"]');
+    expect(spinner).toHaveClass("border-gray-600");
+  });
+
+  // デフォルト値のテスト
+  it("デフォルトではsmサイズとprimaryカラーが適用される", () => {
+    const { container } = render(<Spinner />);
+    const spinner = container.querySelector('[role="status"]');
+    expect(spinner).toHaveClass("h-4", "w-4", "border-blue-600");
+  });
+
+  // アクセシビリティのテスト
+  it("適切なaria属性が設定される", () => {
+    const { container } = render(<Spinner />);
+    const spinner = container.querySelector('[role="status"]');
+    expect(spinner).toHaveAttribute("aria-live", "polite");
+    expect(spinner).toHaveAttribute("aria-label", "読み込み中");
+  });
+
+  // カスタムクラスのテスト
+  it("カスタムクラスを追加できる", () => {
+    const { container } = render(<Spinner className="custom-class" />);
+    const spinner = container.querySelector('[role="status"]');
+    expect(spinner).toHaveClass("custom-class");
+  });
+
+  // 基本的な構造のテスト
+  it("animate-spinクラスでアニメーションが適用される", () => {
+    const { container } = render(<Spinner />);
+    const spinner = container.querySelector('[role="status"]');
+    expect(spinner).toHaveClass("animate-spin");
+  });
+});

--- a/frontend/src/components/ui/Spinner.test.tsx
+++ b/frontend/src/components/ui/Spinner.test.tsx
@@ -3,64 +3,64 @@ import { describe, expect, it } from "vitest";
 import { Spinner } from "./Spinner";
 
 describe("Spinner", () => {
-  // サイズバリエーションのテスト
-  it("smサイズの場合、h-4 w-4クラスが適用される", () => {
-    const { container } = render(<Spinner size="sm" />);
-    const spinner = container.querySelector('[role="status"]');
-    expect(spinner).toHaveClass("h-4", "w-4");
-  });
+	// サイズバリエーションのテスト
+	it("smサイズの場合、h-4 w-4クラスが適用される", () => {
+		const { container } = render(<Spinner size="sm" />);
+		const spinner = container.querySelector('[role="status"]');
+		expect(spinner).toHaveClass("h-4", "w-4");
+	});
 
-  it("mdサイズの場合、h-6 w-6クラスが適用される", () => {
-    const { container } = render(<Spinner size="md" />);
-    const spinner = container.querySelector('[role="status"]');
-    expect(spinner).toHaveClass("h-6", "w-6");
-  });
+	it("mdサイズの場合、h-6 w-6クラスが適用される", () => {
+		const { container } = render(<Spinner size="md" />);
+		const spinner = container.querySelector('[role="status"]');
+		expect(spinner).toHaveClass("h-6", "w-6");
+	});
 
-  it("lgサイズの場合、h-8 w-8クラスが適用される", () => {
-    const { container } = render(<Spinner size="lg" />);
-    const spinner = container.querySelector('[role="status"]');
-    expect(spinner).toHaveClass("h-8", "w-8");
-  });
+	it("lgサイズの場合、h-8 w-8クラスが適用される", () => {
+		const { container } = render(<Spinner size="lg" />);
+		const spinner = container.querySelector('[role="status"]');
+		expect(spinner).toHaveClass("h-8", "w-8");
+	});
 
-  // カラーバリエーションのテスト
-  it("primaryカラーの場合、border-blue-600クラスが適用される", () => {
-    const { container } = render(<Spinner color="primary" />);
-    const spinner = container.querySelector('[role="status"]');
-    expect(spinner).toHaveClass("border-blue-600");
-  });
+	// カラーバリエーションのテスト
+	it("primaryカラーの場合、border-blue-600クラスが適用される", () => {
+		const { container } = render(<Spinner color="primary" />);
+		const spinner = container.querySelector('[role="status"]');
+		expect(spinner).toHaveClass("border-blue-600");
+	});
 
-  it("secondaryカラーの場合、border-gray-600クラスが適用される", () => {
-    const { container } = render(<Spinner color="secondary" />);
-    const spinner = container.querySelector('[role="status"]');
-    expect(spinner).toHaveClass("border-gray-600");
-  });
+	it("secondaryカラーの場合、border-gray-600クラスが適用される", () => {
+		const { container } = render(<Spinner color="secondary" />);
+		const spinner = container.querySelector('[role="status"]');
+		expect(spinner).toHaveClass("border-gray-600");
+	});
 
-  // デフォルト値のテスト
-  it("デフォルトではsmサイズとprimaryカラーが適用される", () => {
-    const { container } = render(<Spinner />);
-    const spinner = container.querySelector('[role="status"]');
-    expect(spinner).toHaveClass("h-4", "w-4", "border-blue-600");
-  });
+	// デフォルト値のテスト
+	it("デフォルトではsmサイズとprimaryカラーが適用される", () => {
+		const { container } = render(<Spinner />);
+		const spinner = container.querySelector('[role="status"]');
+		expect(spinner).toHaveClass("h-4", "w-4", "border-blue-600");
+	});
 
-  // アクセシビリティのテスト
-  it("適切なaria属性が設定される", () => {
-    const { container } = render(<Spinner />);
-    const spinner = container.querySelector('[role="status"]');
-    expect(spinner).toHaveAttribute("aria-live", "polite");
-    expect(spinner).toHaveAttribute("aria-label", "読み込み中");
-  });
+	// アクセシビリティのテスト
+	it("適切なaria属性が設定される", () => {
+		const { container } = render(<Spinner />);
+		const spinner = container.querySelector('[role="status"]');
+		expect(spinner).toHaveAttribute("aria-live", "polite");
+		expect(spinner).toHaveAttribute("aria-label", "読み込み中");
+	});
 
-  // カスタムクラスのテスト
-  it("カスタムクラスを追加できる", () => {
-    const { container } = render(<Spinner className="custom-class" />);
-    const spinner = container.querySelector('[role="status"]');
-    expect(spinner).toHaveClass("custom-class");
-  });
+	// カスタムクラスのテスト
+	it("カスタムクラスを追加できる", () => {
+		const { container } = render(<Spinner className="custom-class" />);
+		const spinner = container.querySelector('[role="status"]');
+		expect(spinner).toHaveClass("custom-class");
+	});
 
-  // 基本的な構造のテスト
-  it("animate-spinクラスでアニメーションが適用される", () => {
-    const { container } = render(<Spinner />);
-    const spinner = container.querySelector('[role="status"]');
-    expect(spinner).toHaveClass("animate-spin");
-  });
+	// 基本的な構造のテスト
+	it("animate-spinクラスでアニメーションが適用される", () => {
+		const { container } = render(<Spinner />);
+		const spinner = container.querySelector('[role="status"]');
+		expect(spinner).toHaveClass("animate-spin");
+	});
 });

--- a/frontend/src/components/ui/Spinner.tsx
+++ b/frontend/src/components/ui/Spinner.tsx
@@ -1,0 +1,36 @@
+import type { FC } from "react";
+
+export interface SpinnerProps {
+  size?: "sm" | "md" | "lg";
+  color?: "primary" | "secondary";
+  className?: string;
+}
+
+const sizeClasses = {
+  sm: "h-4 w-4",
+  md: "h-6 w-6",
+  lg: "h-8 w-8",
+} as const;
+
+const colorClasses = {
+  primary: "border-blue-600",
+  secondary: "border-gray-600",
+} as const;
+
+export const Spinner: FC<SpinnerProps> = ({
+  size = "sm",
+  color = "primary",
+  className = "",
+}) => {
+  const sizeClass = sizeClasses[size];
+  const colorClass = colorClasses[color];
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label="読み込み中"
+      className={`animate-spin rounded-full border-b-2 ${sizeClass} ${colorClass} ${className}`}
+    />
+  );
+};

--- a/frontend/src/components/ui/Spinner.tsx
+++ b/frontend/src/components/ui/Spinner.tsx
@@ -1,36 +1,36 @@
 import type { FC } from "react";
 
 export interface SpinnerProps {
-  size?: "sm" | "md" | "lg";
-  color?: "primary" | "secondary";
-  className?: string;
+	size?: "sm" | "md" | "lg";
+	color?: "primary" | "secondary";
+	className?: string;
 }
 
 const sizeClasses = {
-  sm: "h-4 w-4",
-  md: "h-6 w-6",
-  lg: "h-8 w-8",
+	sm: "h-4 w-4",
+	md: "h-6 w-6",
+	lg: "h-8 w-8",
 } as const;
 
 const colorClasses = {
-  primary: "border-blue-600",
-  secondary: "border-gray-600",
+	primary: "border-blue-600",
+	secondary: "border-gray-600",
 } as const;
 
 export const Spinner: FC<SpinnerProps> = ({
-  size = "sm",
-  color = "primary",
-  className = "",
+	size = "sm",
+	color = "primary",
+	className = "",
 }) => {
-  const sizeClass = sizeClasses[size];
-  const colorClass = colorClasses[color];
+	const sizeClass = sizeClasses[size];
+	const colorClass = colorClasses[color];
 
-  return (
-    <div
-      role="status"
-      aria-live="polite"
-      aria-label="読み込み中"
-      className={`animate-spin rounded-full border-b-2 ${sizeClass} ${colorClass} ${className}`}
-    />
-  );
+	return (
+		<div
+			role="status"
+			aria-live="polite"
+			aria-label="読み込み中"
+			className={`animate-spin rounded-full border-b-2 ${sizeClass} ${colorClass} ${className}`}
+		/>
+	);
 };

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -1,26 +1,3 @@
-/**
- * UI Components Barrel Export
- *
- * 汎用UIコンポーネントの統一エクスポートファイル
- * プロジェクト全体で使用される再利用可能なUIコンポーネントをまとめて管理
- *
- * 使用方法:
- * import { Dialog } from '@/components/ui';
- *
- * 設計方針:
- * - 他のコンポーネントから簡単にインポートできるよう統一されたエクスポート
- * - コンポーネント追加時にはここに追加してアクセシビリティを向上
- * - 型定義も含めてエクスポートし、TypeScriptの恩恵を最大化
- */
-
-export type { DialogProps } from "./Dialog";
-// Dialog関連のエクスポート
-export { Dialog } from "./Dialog";
-
-// 将来追加予定のUIコンポーネント
-// export { Button } from './Button';
-// export { Input } from './Input';
-// export { Modal } from './Modal';
-// export { Tooltip } from './Tooltip';
-// export { Card } from './Card';
-// export { Badge } from './Badge';
+export { LoadingState, type LoadingStateProps } from "./LoadingState";
+export { Skeleton, type SkeletonProps } from "./Skeleton";
+export { Spinner, type SpinnerProps } from "./Spinner";

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -1,3 +1,4 @@
+export { Dialog, type DialogProps } from "./Dialog";
 export { LoadingState, type LoadingStateProps } from "./LoadingState";
 export { Skeleton, type SkeletonProps } from "./Skeleton";
 export { Spinner, type SpinnerProps } from "./Spinner";


### PR DESCRIPTION
## 概要

ローディング状態のUIを統一し、視覚的な一貫性とコードの保守性を向上させました。

close #252

## 変更内容

### 共通ローディングコンポーネントの作成
- **Spinner**: サイズ(sm/md/lg)とカラー(primary/secondary)のバリエーションを提供
- **LoadingState**: インライン/ブロック/フルページのレイアウトパターンに対応  
- **Skeleton**: テキスト/矩形/円形のバリエーションでスケルトンローディングを実装

### 既存コンポーネントのリファクタリング
- ExpenseListとSubscriptionListの重複したLoadingStateコンポーネントを削除
- ExpenseStatsのスケルトンローダーを共通のSkeletonコンポーネントに置換
- 統一されたローディングUIにより、一貫性のあるユーザー体験を提供

### 品質保証
- 各コンポーネントに対する包括的なユニットテスト（31個のテストを追加）
- Storybookストーリーによる視覚的なドキュメント化
- E2Eテストによるローディング状態の統一性検証
- アクセシビリティ対応（role="status"、aria-live、aria-busy属性）

## テスト実行結果
- ✅ 型チェック: パス
- ✅ Lint: パス（Biome）
- ✅ ユニットテスト: 713個すべてパス

## 関連ファイル
作成:
- `frontend/src/components/ui/Spinner.tsx`
- `frontend/src/components/ui/LoadingState.tsx`
- `frontend/src/components/ui/Skeleton.tsx`
- 各コンポーネントのテストとStorybookファイル
- `e2e/tests/loading-states.spec.ts`

修正:
- `frontend/src/components/expenses/ExpenseList.tsx`
- `frontend/src/components/subscriptions/SubscriptionList.tsx`
- `frontend/src/components/expenses/ExpenseStats.tsx`

🤖 Generated with [Claude Code](https://claude.ai/code)