### PR TITLE
fix: issue-333 不要なパフォーマンステストの削除

### DIFF
--- a/api/src/__tests__/integration/subscriptions.integration.test.ts
+++ b/api/src/__tests__/integration/subscriptions.integration.test.ts
@@ -274,42 +274,4 @@ describe('Subscriptions API - Integration Tests', () => {
 			expect([1000, 2000]).toContain(finalData.amount)
 		})
 	})
-
-	describe('Performance and Scalability', () => {
-		it('should handle large number of subscriptions', async () => {
-			// 大量データでのパフォーマンステスト（必要に応じて）
-			const subscriptionsToCreate = 10 // テスト環境では小さな数値で
-
-			// 複数のサブスクリプションを作成
-			const createPromises = Array.from({ length: subscriptionsToCreate }, (_, i) => {
-				const subscription = {
-					...testSubscriptions.netflix,
-					name: `Test Service ${i}`,
-					amount: 1000 + i * 100,
-					categoryId: 1,
-				}
-				return createTestRequest(testProductionApp, 'POST', '/api/subscriptions', subscription)
-			})
-
-			const responses = await Promise.all(createPromises)
-
-			// すべて成功していることを確認
-			for (const response of responses) {
-				expect(response.status).toBe(201)
-			}
-
-			// 一覧取得のパフォーマンス測定
-			const start = Date.now()
-			const response = await createTestRequest(testProductionApp, 'GET', '/api/subscriptions')
-			const duration = Date.now() - start
-
-			expect(response.status).toBe(200)
-
-			const data = await getResponseJson(response)
-			expect(data.length).toBeGreaterThanOrEqual(subscriptionsToCreate)
-
-			// レスポンス時間が合理的な範囲内であることを確認
-			expect(duration).toBeLessThan(5000) // 5秒以内
-		})
-	})
 })


### PR DESCRIPTION
## Summary
- subscriptions.integration.test.ts から不要なパフォーマンステストを削除
- CI環境での実行時間短縮に貢献

## 変更内容
- 「Performance and Scalability」テストセクション（38行）を削除
  - 大量データ（10件）のサブスクリプション作成テスト
  - レスポンスタイム測定（5秒以内の制約）

## なぜこの変更が必要か
- パフォーマンステストは統合テストの範囲を超えている
- 実際のパフォーマンステストは専用の環境で実施すべき
- CI実行時間の短縮に貢献

## Test plan
✅ API全テスト（146件）が成功
✅ 型チェック・リントエラーなし

Closes #333

🤖 Generated with [Claude Code](https://claude.ai/code)