### PR TITLE
feat: issue-353 共通バリデーションフレームワークの実装

### DIFF
--- a/docs/validation-framework.md
+++ b/docs/validation-framework.md
@@ -1,0 +1,240 @@
+# バリデーションフレームワーク
+
+## 概要
+
+`shared/src/validation/index.ts` で定義される共通バリデーションフレームワークは、API/Frontend間で一貫性のあるバリデーションロジックを提供します。
+
+## 主な特徴
+
+- **型安全性**: TypeScriptの型システムを活用した型安全なバリデーション
+- **コンポーザブル**: 複数のバリデーターを組み合わせて複雑なルールを構築可能
+- **統一された制限値**: API/Frontend間で同じ制限値を使用
+- **標準化されたエラーメッセージ**: 一貫性のあるユーザーフレンドリーなエラーメッセージ
+
+## 基本的な使い方
+
+### 1. 単一フィールドのバリデーション
+
+```typescript
+import { required, numeric, positiveNumber } from 'shared/src/validation';
+
+// 必須チェック
+const nameValidator = required<string>();
+const error = nameValidator('', 'name'); // { field: 'name', message: 'nameは必須です', code: 'REQUIRED' }
+
+// 数値範囲チェック
+const ageValidator = numeric(0, 120);
+const error = ageValidator(150, 'age'); // { field: 'age', message: 'ageは120以下である必要があります', code: 'MAX_VALUE' }
+
+// 正の数チェック
+const amountValidator = positiveNumber();
+const error = amountValidator(-100, 'amount'); // エラー
+```
+
+### 2. 複数のバリデーターの組み合わせ
+
+```typescript
+import { compose, required, numeric, VALIDATION_LIMITS } from 'shared/src/validation';
+
+// 金額バリデーター: 必須 + 正の数 + 上限チェック
+const amountValidator = compose(
+  required<number>(),
+  positiveNumber(),
+  numeric(VALIDATION_LIMITS.MIN_AMOUNT, VALIDATION_LIMITS.MAX_AMOUNT)
+);
+
+const error = amountValidator(null, 'amount'); // 必須エラー
+const error2 = amountValidator(-100, 'amount'); // 正の数エラー
+const error3 = amountValidator(20000000, 'amount'); // 上限エラー
+```
+
+### 3. オブジェクト全体のバリデーション
+
+```typescript
+import { validateObject, validators } from 'shared/src/validation';
+
+const transactionData = {
+  name: '昼食',
+  amount: 1000,
+  date: '2024-01-01',
+  description: 'ランチ代'
+};
+
+const result = validateObject(transactionData, {
+  name: validators.name,
+  amount: validators.amount,
+  date: validators.date,
+  description: validators.description
+});
+
+if (result.success) {
+  // バリデーション成功
+  console.log(result.data); // 型安全なデータ
+} else {
+  // バリデーション失敗
+  console.log(result.errors); // エラーの配列
+}
+```
+
+## 利用可能なバリデーター
+
+### 基本バリデーター
+
+| バリデーター | 説明 | 使用例 |
+|------------|------|-------|
+| `required()` | 必須フィールドチェック | `required<string>()` |
+| `numeric(min?, max?)` | 数値範囲チェック | `numeric(0, 100)` |
+| `positiveNumber()` | 正の数チェック | `positiveNumber()` |
+| `string(maxLength?)` | 文字列長チェック | `string(100)` |
+| `date(minDate?)` | 日付チェック | `date(new Date('2000-01-01'))` |
+| `enumValidator(values)` | 列挙値チェック | `enumValidator(['A', 'B', 'C'])` |
+
+### プリセットバリデーター
+
+```typescript
+import { validators } from 'shared/src/validation';
+
+// 金額: 必須 + 正の数 + ¥1〜¥10,000,000
+validators.amount
+
+// 名前: 必須 + 最大100文字
+validators.name
+
+// 説明: オプショナル + 最大500文字
+validators.description
+
+// 日付: 必須 + 2000年1月1日以降
+validators.date
+```
+
+## 共通制限値
+
+```typescript
+import { VALIDATION_LIMITS } from 'shared/src/validation';
+
+// 金額の制限
+VALIDATION_LIMITS.MAX_AMOUNT // ¥10,000,000
+VALIDATION_LIMITS.MIN_AMOUNT // ¥1
+
+// 文字列長の制限
+VALIDATION_LIMITS.MAX_NAME_LENGTH // 100文字
+VALIDATION_LIMITS.MAX_DESCRIPTION_LENGTH // 500文字
+
+// 日付の制限
+VALIDATION_LIMITS.MIN_DATE // 2000-01-01
+```
+
+## API/Frontendでの使用例
+
+### Frontendでの使用
+
+```typescript
+// frontend/src/components/ExpenseForm.tsx
+import { validateObject, validators } from 'shared/src/validation';
+
+const handleSubmit = (formData: FormData) => {
+  const result = validateObject(formData, {
+    name: validators.name,
+    amount: validators.amount,
+    date: validators.date,
+    description: validators.description
+  });
+
+  if (!result.success) {
+    // エラー表示
+    result.errors.forEach(error => {
+      showError(error.field, error.message);
+    });
+    return;
+  }
+
+  // バリデーション成功、APIへ送信
+  submitToAPI(result.data);
+};
+```
+
+### APIでの使用
+
+```typescript
+// api/src/routes/transactions.ts
+import { validateObject, validators } from 'shared/src/validation';
+
+app.post('/api/transactions', async (c) => {
+  const body = await c.req.json();
+  
+  const result = validateObject(body, {
+    name: validators.name,
+    amount: validators.amount,
+    date: validators.date,
+    categoryId: compose(required<number>(), numeric(1))
+  });
+
+  if (!result.success) {
+    return c.json({ errors: result.errors }, 400);
+  }
+
+  // バリデーション成功、データベースへ保存
+  const transaction = await createTransaction(result.data);
+  return c.json(transaction);
+});
+```
+
+## カスタムバリデーターの作成
+
+```typescript
+import { type Validator, ERROR_MESSAGES } from 'shared/src/validation';
+
+// カタカナのみを許可するバリデーター
+const katakanaOnly: Validator<string> = (value: string, fieldName: string) => {
+  if (!/^[ァ-ヶー]*$/.test(value)) {
+    return {
+      field: fieldName,
+      message: `${fieldName}はカタカナのみ入力可能です`,
+      code: 'KATAKANA_ONLY'
+    };
+  }
+  return null;
+};
+
+// 使用例
+const nameValidator = compose(
+  required<string>(),
+  katakanaOnly
+);
+```
+
+## 型定義
+
+```typescript
+// バリデーション結果の型
+type ValidationResult<T> = 
+  | { success: true; data: T }
+  | { success: false; errors: ValidationError[] };
+
+// エラーの型
+interface ValidationError {
+  field: string;      // エラーが発生したフィールド名
+  message: string;    // エラーメッセージ
+  code?: string;      // エラーコード（オプション）
+}
+
+// バリデーター関数の型
+type Validator<T> = (value: T, fieldName: string) => ValidationError | null;
+```
+
+## ベストプラクティス
+
+1. **共通の制限値を使用**: ハードコードせず、`VALIDATION_LIMITS`を使用
+2. **プリセットバリデーターを活用**: 一般的なケースには`validators`オブジェクトを使用
+3. **エラーメッセージの一貫性**: カスタムメッセージは本当に必要な場合のみ使用
+4. **型安全性の維持**: ジェネリクスを適切に使用してタイプセーフティを確保
+5. **組み合わせて使用**: `compose`を使って複雑なバリデーションルールを構築
+
+## 今後の拡張
+
+このフレームワークは、今後以下の機能で拡張可能です：
+
+- 非同期バリデーション（データベースチェックなど）
+- 条件付きバリデーション（他のフィールドに依存）
+- 国際化対応（多言語エラーメッセージ）
+- より高度なバリデーター（メールアドレス、URL、電話番号など）

--- a/shared/src/validation/__tests__/index.test.ts
+++ b/shared/src/validation/__tests__/index.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it } from 'vitest';
+import {
+  required,
+  numeric,
+  positiveNumber,
+  string,
+  date,
+  enumValidator,
+  compose,
+  validateObject,
+  validators,
+  VALIDATION_LIMITS,
+  type ValidationError,
+} from '../index';
+
+describe('Validation Framework', () => {
+  describe('required validator', () => {
+    it('nullを拒否する', () => {
+      const validator = required();
+      const result = validator(null, 'field');
+      expect(result).toEqual({
+        field: 'field',
+        message: 'fieldは必須です',
+        code: 'REQUIRED',
+      });
+    });
+
+    it('undefinedを拒否する', () => {
+      const validator = required();
+      const result = validator(undefined, 'field');
+      expect(result).toEqual({
+        field: 'field',
+        message: 'fieldは必須です',
+        code: 'REQUIRED',
+      });
+    });
+
+    it('空文字列を拒否する', () => {
+      const validator = required<string>();
+      const result = validator('', 'field');
+      expect(result).toEqual({
+        field: 'field',
+        message: 'fieldは必須です',
+        code: 'REQUIRED',
+      });
+    });
+
+    it('有効な値を受け入れる', () => {
+      const validator = required<string>();
+      expect(validator('value', 'field')).toBeNull();
+      expect(validator(0, 'field')).toBeNull();
+      expect(validator(false, 'field')).toBeNull();
+    });
+
+    it('カスタムメッセージをサポートする', () => {
+      const validator = required('カスタムエラー');
+      const result = validator(null, 'field');
+      expect(result?.message).toBe('カスタムエラー');
+    });
+  });
+
+  describe('numeric validator', () => {
+    it('数値でない値を拒否する', () => {
+      const validator = numeric();
+      const result = validator('not a number' as any, 'field');
+      expect(result).toEqual({
+        field: 'field',
+        message: 'fieldは数値である必要があります',
+        code: 'INVALID_NUMBER',
+      });
+    });
+
+    it('NaNを拒否する', () => {
+      const validator = numeric();
+      const result = validator(NaN, 'field');
+      expect(result).toEqual({
+        field: 'field',
+        message: 'fieldは数値である必要があります',
+        code: 'INVALID_NUMBER',
+      });
+    });
+
+    it('最小値チェックを行う', () => {
+      const validator = numeric(10);
+      expect(validator(9, 'field')).toEqual({
+        field: 'field',
+        message: 'fieldは10以上である必要があります',
+        code: 'MIN_VALUE',
+      });
+      expect(validator(10, 'field')).toBeNull();
+      expect(validator(11, 'field')).toBeNull();
+    });
+
+    it('最大値チェックを行う', () => {
+      const validator = numeric(undefined, 100);
+      expect(validator(101, 'field')).toEqual({
+        field: 'field',
+        message: 'fieldは100以下である必要があります',
+        code: 'MAX_VALUE',
+      });
+      expect(validator(100, 'field')).toBeNull();
+      expect(validator(99, 'field')).toBeNull();
+    });
+
+    it('範囲チェックを行う', () => {
+      const validator = numeric(10, 100);
+      expect(validator(9, 'field')?.code).toBe('MIN_VALUE');
+      expect(validator(101, 'field')?.code).toBe('MAX_VALUE');
+      expect(validator(50, 'field')).toBeNull();
+    });
+  });
+
+  describe('positiveNumber validator', () => {
+    it('正の数を受け入れる', () => {
+      const validator = positiveNumber();
+      expect(validator(1, 'field')).toBeNull();
+      expect(validator(100, 'field')).toBeNull();
+      expect(validator(0.1, 'field')).toBeNull();
+    });
+
+    it('ゼロ以下を拒否する', () => {
+      const validator = positiveNumber();
+      expect(validator(0, 'field')).toEqual({
+        field: 'field',
+        message: 'fieldは正の数値である必要があります',
+        code: 'POSITIVE_NUMBER',
+      });
+      expect(validator(-1, 'field')).toBeTruthy();
+    });
+  });
+
+  describe('string validator', () => {
+    it('文字列でない値を拒否する', () => {
+      const validator = string();
+      const result = validator(123 as any, 'field');
+      expect(result).toEqual({
+        field: 'field',
+        message: 'fieldは文字列である必要があります',
+        code: 'INVALID_STRING',
+      });
+    });
+
+    it('最大長チェックを行う', () => {
+      const validator = string(5);
+      expect(validator('12345', 'field')).toBeNull();
+      expect(validator('123456', 'field')).toEqual({
+        field: 'field',
+        message: 'fieldは5文字以下である必要があります',
+        code: 'MAX_LENGTH',
+      });
+    });
+
+    it('空文字列を受け入れる', () => {
+      const validator = string(10);
+      expect(validator('', 'field')).toBeNull();
+    });
+  });
+
+  describe('date validator', () => {
+    it('有効な日付を受け入れる', () => {
+      const validator = date();
+      expect(validator(new Date(), 'field')).toBeNull();
+      expect(validator('2024-01-01', 'field')).toBeNull();
+    });
+
+    it('無効な日付を拒否する', () => {
+      const validator = date();
+      expect(validator('invalid date', 'field')).toEqual({
+        field: 'field',
+        message: 'fieldは有効な日付である必要があります',
+        code: 'INVALID_DATE',
+      });
+    });
+
+    it('最小日付チェックを行う', () => {
+      const minDate = new Date('2024-01-01');
+      const validator = date(minDate);
+      
+      expect(validator('2023-12-31', 'field')).toEqual({
+        field: 'field',
+        message: 'fieldは2024-01-01以降である必要があります',
+        code: 'MIN_DATE',
+      });
+      expect(validator('2024-01-01', 'field')).toBeNull();
+      expect(validator('2024-01-02', 'field')).toBeNull();
+    });
+  });
+
+  describe('enumValidator', () => {
+    it('許可された値を受け入れる', () => {
+      const validator = enumValidator(['A', 'B', 'C'] as const);
+      expect(validator('A', 'field')).toBeNull();
+      expect(validator('B', 'field')).toBeNull();
+      expect(validator('C', 'field')).toBeNull();
+    });
+
+    it('許可されていない値を拒否する', () => {
+      const validator = enumValidator(['A', 'B', 'C'] as const);
+      expect(validator('D' as any, 'field')).toEqual({
+        field: 'field',
+        message: 'fieldはA, B, Cのいずれかである必要があります',
+        code: 'INVALID_ENUM',
+      });
+    });
+
+    it('数値のenumをサポートする', () => {
+      const validator = enumValidator([1, 2, 3] as const);
+      expect(validator(1, 'field')).toBeNull();
+      expect(validator(4 as any, 'field')).toBeTruthy();
+    });
+  });
+
+  describe('compose validator', () => {
+    it('複数のバリデーターを順番に実行する', () => {
+      const validator = compose(
+        required<number>(),
+        numeric(0, 100)
+      );
+      
+      expect(validator(null as any, 'field')?.code).toBe('REQUIRED');
+      expect(validator(101, 'field')?.code).toBe('MAX_VALUE');
+      expect(validator(50, 'field')).toBeNull();
+    });
+
+    it('最初のエラーで停止する', () => {
+      const validator = compose(
+        required<number>(),
+        positiveNumber(),
+        numeric(0, 100)
+      );
+      
+      // requiredで失敗するので、positiveNumberは実行されない
+      const result = validator(null as any, 'field');
+      expect(result?.code).toBe('REQUIRED');
+    });
+  });
+
+  describe('validateObject', () => {
+    it('オブジェクト全体をバリデートする', () => {
+      const data = {
+        name: 'テスト',
+        amount: 1000,
+        description: '説明',
+      };
+
+      const result = validateObject(data, {
+        name: required<string>(),
+        amount: compose(required<number>(), positiveNumber()),
+        description: string(100),
+      });
+
+      expect(result).toEqual({ success: true, data });
+    });
+
+    it('複数のエラーを収集する', () => {
+      const data = {
+        name: '',
+        amount: -100,
+        description: 'a'.repeat(101),
+      };
+
+      const result = validateObject(data, {
+        name: required<string>(),
+        amount: positiveNumber(),
+        description: string(100),
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.errors).toHaveLength(3);
+        expect(result.errors.map(e => e.field)).toEqual(['name', 'amount', 'description']);
+      }
+    });
+
+    it('配列形式のバリデーターをサポートする', () => {
+      const data = { amount: 50 };
+      
+      const result = validateObject(data, {
+        amount: [required<number>(), positiveNumber(), numeric(0, 100)],
+      });
+
+      expect(result).toEqual({ success: true, data });
+    });
+  });
+
+  describe('preset validators', () => {
+    it('amount validatorが正しく動作する', () => {
+      expect(validators.amount(null as any, 'amount')?.code).toBe('REQUIRED');
+      expect(validators.amount(0, 'amount')?.code).toBe('POSITIVE_NUMBER');
+      expect(validators.amount(VALIDATION_LIMITS.MAX_AMOUNT + 1, 'amount')?.code).toBe('MAX_VALUE');
+      expect(validators.amount(1000, 'amount')).toBeNull();
+    });
+
+    it('name validatorが正しく動作する', () => {
+      expect(validators.name('', 'name')?.code).toBe('REQUIRED');
+      expect(validators.name('a'.repeat(VALIDATION_LIMITS.MAX_NAME_LENGTH + 1), 'name')?.code).toBe('MAX_LENGTH');
+      expect(validators.name('テスト名', 'name')).toBeNull();
+    });
+
+    it('description validatorが正しく動作する', () => {
+      // descriptionはオプショナルなのでnullやundefinedは受け入れる
+      expect(validators.description(null as any, 'description')).toBeNull();
+      expect(validators.description('a'.repeat(VALIDATION_LIMITS.MAX_DESCRIPTION_LENGTH + 1), 'description')?.code).toBe('MAX_LENGTH');
+      expect(validators.description('説明文', 'description')).toBeNull();
+    });
+
+    it('date validatorが正しく動作する', () => {
+      expect(validators.date(null as any, 'date')?.code).toBe('REQUIRED');
+      expect(validators.date('1999-12-31', 'date')?.code).toBe('MIN_DATE');
+      expect(validators.date('2024-01-01', 'date')).toBeNull();
+    });
+  });
+
+  describe('validation limits', () => {
+    it('期待される制限値を持つ', () => {
+      expect(VALIDATION_LIMITS.MAX_AMOUNT).toBe(10_000_000);
+      expect(VALIDATION_LIMITS.MIN_AMOUNT).toBe(1);
+      expect(VALIDATION_LIMITS.MAX_NAME_LENGTH).toBe(100);
+      expect(VALIDATION_LIMITS.MAX_DESCRIPTION_LENGTH).toBe(500);
+      expect(VALIDATION_LIMITS.MIN_DATE).toEqual(new Date('2000-01-01'));
+    });
+  });
+});

--- a/shared/src/validation/index.ts
+++ b/shared/src/validation/index.ts
@@ -1,0 +1,239 @@
+// 共通バリデーションフレームワーク
+// API/Frontend間で共有される型安全なバリデーションロジックを提供
+
+// バリデーション結果の型定義
+export type ValidationResult<T = unknown> = 
+  | { success: true; data: T }
+  | { success: false; errors: ValidationError[] };
+
+// バリデーションエラーの型定義
+export interface ValidationError {
+  field: string;
+  message: string;
+  code?: string;
+}
+
+// バリデーター関数の型定義
+export type Validator<T = unknown> = (value: T, fieldName: string) => ValidationError | null;
+
+// バリデーションルールの型定義
+export interface ValidationRule<T = unknown> {
+  validator: Validator<T>;
+  message?: string;
+}
+
+// 共通バリデーション定数
+export const VALIDATION_LIMITS = {
+  // 金額の上限（API/Frontend統一）
+  MAX_AMOUNT: 10_000_000, // ¥10,000,000
+  MIN_AMOUNT: 1,
+  
+  // 文字列長の上限
+  MAX_NAME_LENGTH: 100,
+  MAX_DESCRIPTION_LENGTH: 500,
+  
+  // その他の制約
+  MIN_DATE: new Date('2000-01-01'),
+} as const;
+
+// エラーメッセージテンプレート
+export const ERROR_MESSAGES = {
+  REQUIRED: '{field}は必須です',
+  MIN_VALUE: '{field}は{min}以上である必要があります',
+  MAX_VALUE: '{field}は{max}以下である必要があります',
+  MAX_LENGTH: '{field}は{max}文字以下である必要があります',
+  INVALID_DATE: '{field}は有効な日付である必要があります',
+  INVALID_ENUM: '{field}は{values}のいずれかである必要があります',
+  POSITIVE_NUMBER: '{field}は正の数値である必要があります',
+} as const;
+
+// 必須フィールドバリデーター
+export const required = <T>(customMessage?: string): Validator<T> => {
+  return (value: T, fieldName: string): ValidationError | null => {
+    if (value === null || value === undefined || value === '') {
+      return {
+        field: fieldName,
+        message: customMessage || ERROR_MESSAGES.REQUIRED.replace('{field}', fieldName),
+        code: 'REQUIRED',
+      };
+    }
+    return null;
+  };
+};
+
+// 数値範囲バリデーター
+export const numeric = (min?: number, max?: number, customMessage?: string): Validator<number> => {
+  return (value: number, fieldName: string): ValidationError | null => {
+    if (typeof value !== 'number' || Number.isNaN(value)) {
+      return {
+        field: fieldName,
+        message: customMessage || `${fieldName}は数値である必要があります`,
+        code: 'INVALID_NUMBER',
+      };
+    }
+    
+    if (min !== undefined && value < min) {
+      return {
+        field: fieldName,
+        message: customMessage || ERROR_MESSAGES.MIN_VALUE.replace('{field}', fieldName).replace('{min}', min.toString()),
+        code: 'MIN_VALUE',
+      };
+    }
+    
+    if (max !== undefined && value > max) {
+      return {
+        field: fieldName,
+        message: customMessage || ERROR_MESSAGES.MAX_VALUE.replace('{field}', fieldName).replace('{max}', max.toString()),
+        code: 'MAX_VALUE',
+      };
+    }
+    
+    return null;
+  };
+};
+
+// 正の数値バリデーター
+export const positiveNumber = (customMessage?: string): Validator<number> => {
+  return (value: number, fieldName: string): ValidationError | null => {
+    if (typeof value !== 'number' || Number.isNaN(value) || value <= 0) {
+      return {
+        field: fieldName,
+        message: customMessage || ERROR_MESSAGES.POSITIVE_NUMBER.replace('{field}', fieldName),
+        code: 'POSITIVE_NUMBER',
+      };
+    }
+    return null;
+  };
+};
+
+// 文字列長バリデーター
+export const string = (maxLength?: number, customMessage?: string): Validator<string> => {
+  return (value: string, fieldName: string): ValidationError | null => {
+    // null/undefinedは許可する（オプショナルフィールド用）
+    if (value === null || value === undefined) {
+      return null;
+    }
+    
+    if (typeof value !== 'string') {
+      return {
+        field: fieldName,
+        message: customMessage || `${fieldName}は文字列である必要があります`,
+        code: 'INVALID_STRING',
+      };
+    }
+    
+    if (maxLength !== undefined && value.length > maxLength) {
+      return {
+        field: fieldName,
+        message: customMessage || ERROR_MESSAGES.MAX_LENGTH.replace('{field}', fieldName).replace('{max}', maxLength.toString()),
+        code: 'MAX_LENGTH',
+      };
+    }
+    
+    return null;
+  };
+};
+
+// 日付バリデーター
+export const date = (minDate?: Date, customMessage?: string): Validator<Date | string> => {
+  return (value: Date | string, fieldName: string): ValidationError | null => {
+    const dateValue = typeof value === 'string' ? new Date(value) : value;
+    
+    if (!(dateValue instanceof Date) || Number.isNaN(dateValue.getTime())) {
+      return {
+        field: fieldName,
+        message: customMessage || ERROR_MESSAGES.INVALID_DATE.replace('{field}', fieldName),
+        code: 'INVALID_DATE',
+      };
+    }
+    
+    if (minDate && dateValue < minDate) {
+      return {
+        field: fieldName,
+        message: customMessage || `${fieldName}は${minDate.toISOString().split('T')[0]}以降である必要があります`,
+        code: 'MIN_DATE',
+      };
+    }
+    
+    return null;
+  };
+};
+
+// Enumバリデーター
+export const enumValidator = <T extends string | number>(allowedValues: readonly T[], customMessage?: string): Validator<T> => {
+  return (value: T, fieldName: string): ValidationError | null => {
+    if (!allowedValues.includes(value)) {
+      return {
+        field: fieldName,
+        message: customMessage || ERROR_MESSAGES.INVALID_ENUM.replace('{field}', fieldName).replace('{values}', allowedValues.join(', ')),
+        code: 'INVALID_ENUM',
+      };
+    }
+    return null;
+  };
+};
+
+// バリデーター合成関数
+export const compose = <T>(...validators: Validator<T>[]): Validator<T> => {
+  return (value: T, fieldName: string): ValidationError | null => {
+    for (const validator of validators) {
+      const error = validator(value, fieldName);
+      if (error) {
+        return error;
+      }
+    }
+    return null;
+  };
+};
+
+// オブジェクトバリデーション関数
+export const validateObject = <T extends Record<string, unknown>>(
+  data: T,
+  rules: Partial<Record<keyof T, Validator<T[keyof T]> | Validator<T[keyof T]>[]>>
+): ValidationResult<T> => {
+  const errors: ValidationError[] = [];
+  
+  for (const [field, rule] of Object.entries(rules) as [keyof T, Validator<T[keyof T]> | Validator<T[keyof T]>[]][]) {
+    const value = data[field];
+    const validators = Array.isArray(rule) ? rule : [rule];
+    
+    for (const validator of validators) {
+      const error = validator(value, String(field));
+      if (error) {
+        errors.push(error);
+        break; // 最初のエラーで次のフィールドへ
+      }
+    }
+  }
+  
+  if (errors.length > 0) {
+    return { success: false, errors };
+  }
+  
+  return { success: true, data };
+};
+
+// 便利なプリセットバリデーター
+export const validators = {
+  // 金額バリデーター（必須 + 正の数 + 上限チェック）
+  amount: compose(
+    required<number>(),
+    positiveNumber(),
+    numeric(VALIDATION_LIMITS.MIN_AMOUNT, VALIDATION_LIMITS.MAX_AMOUNT)
+  ),
+  
+  // 名前バリデーター（必須 + 文字列長）
+  name: compose(
+    required<string>(),
+    string(VALIDATION_LIMITS.MAX_NAME_LENGTH)
+  ),
+  
+  // 説明バリデーター（オプショナル + 文字列長）
+  description: string(VALIDATION_LIMITS.MAX_DESCRIPTION_LENGTH),
+  
+  // 日付バリデーター（必須 + 最小日付）
+  date: compose(
+    required<Date | string>(),
+    date(VALIDATION_LIMITS.MIN_DATE)
+  ),
+} as const;


### PR DESCRIPTION
## Summary
- 共通バリデーションフレームワーク `shared/src/validation/index.ts` を実装
- API/Frontend間で一貫性のあるバリデーションロジックを提供
- 型安全性とコンポーザブルなバリデーションルールをサポート

## 実装内容
### バリデーター
- 基本バリデーター: `required`, `numeric`, `positiveNumber`, `string`, `date`, `enumValidator`
- コンポーザブル機能: `compose` でバリデーターを組み合わせ可能
- プリセットバリデーター: `amount`, `name`, `description`, `date`

### 統一された制限値
- 金額上限: ¥10,000,000（API/Frontend統一）
- 名前: 最大100文字
- 説明: 最大500文字
- 日付: 2000年1月1日以降

### テスト
- 包括的なユニットテスト（31テスト、100%パス）
- 全バリデーターの正常系・異常系をカバー

### ドキュメント
- [バリデーションフレームワーク使用ガイド](./docs/validation-framework.md)

## Test plan
- [x] ユニットテスト実行: 全31テストがパス
- [x] 型チェック: エラーなし
- [x] リントチェック: Biome準拠
- [ ] API/Frontendでの実装（後続タスク）

Closes #353

🤖 Generated with [Claude Code](https://claude.ai/code)