### PR TITLE
fix: issue-363 サブスクリプション作成時のバリデーションエラーを修正

### DIFF
--- a/api/src/validation/schemas.ts
+++ b/api/src/validation/schemas.ts
@@ -293,7 +293,13 @@ export function validateSubscriptionCreate(
 	const errors: ValidationError[] = []
 
 	// 必須フィールドのチェック
-	const requiredFields = ['name', 'amount', 'billingCycle', 'nextBillingDate'] as const
+	const requiredFields = [
+		'name',
+		'amount',
+		'categoryId',
+		'billingCycle',
+		'nextBillingDate',
+	] as const
 	for (const field of requiredFields) {
 		if (data[field] === undefined || data[field] === null) {
 			errors.push({

--- a/frontend/src/lib/api/subscriptions/api.ts
+++ b/frontend/src/lib/api/subscriptions/api.ts
@@ -29,7 +29,8 @@ export async function fetchSubscriptions(
 		);
 	} catch (error) {
 		console.error("Failed to fetch subscriptions:", error);
-		throw new Error("サブスクリプション一覧の取得に失敗しました");
+		// エラーオブジェクトをそのまま再スローして、上位でエラーハンドリングできるようにする
+		throw error;
 	}
 }
 
@@ -51,7 +52,8 @@ export async function fetchSubscriptionById(
 		return transformApiSubscriptionToFrontend(response, categories);
 	} catch (error) {
 		console.error(`Failed to fetch subscription ${id}:`, error);
-		throw new Error("サブスクリプション詳細の取得に失敗しました");
+		// エラーオブジェクトをそのまま再スローして、上位でエラーハンドリングできるようにする
+		throw error;
 	}
 }
 
@@ -75,7 +77,8 @@ export async function createSubscription(
 		return transformApiSubscriptionToFrontend(response, categories);
 	} catch (error) {
 		console.error("Failed to create subscription:", error);
-		throw new Error("サブスクリプションの作成に失敗しました");
+		// エラーオブジェクトをそのまま再スローして、上位でエラーハンドリングできるようにする
+		throw error;
 	}
 }
 
@@ -101,7 +104,8 @@ export async function updateSubscription(
 		return transformApiSubscriptionToFrontend(response, categories);
 	} catch (error) {
 		console.error(`Failed to update subscription ${id}:`, error);
-		throw new Error("サブスクリプションの更新に失敗しました");
+		// エラーオブジェクトをそのまま再スローして、上位でエラーハンドリングできるようにする
+		throw error;
 	}
 }
 
@@ -114,7 +118,8 @@ export async function deleteSubscription(id: string): Promise<void> {
 		await apiClient.delete(`/subscriptions/${id}`);
 	} catch (error) {
 		console.error(`Failed to delete subscription ${id}:`, error);
-		throw new Error("サブスクリプションの削除に失敗しました");
+		// エラーオブジェクトをそのまま再スローして、上位でエラーハンドリングできるようにする
+		throw error;
 	}
 }
 


### PR DESCRIPTION
## 概要
- サブスクリプション作成時のPOSTリクエストでバリデーションエラーが発生する問題を修正
- フロントエンドとAPIのバリデーションルールの不整合を解消

## 変更内容
### API側
- `api/src/validation/schemas.ts`: `categoryId`を必須フィールドに追加
  - フロントエンドではカテゴリIDが必須となっているため、API側でも必須に統一

### フロントエンド側
- `frontend/src/lib/api/subscriptions/api.ts`: エラーハンドリングを改善
  - 汎用的なエラーメッセージではなく、実際のAPIエラーをそのまま上位に伝播するよう修正
  - これにより、より詳細なエラー情報をユーザーに表示可能

## テスト結果
- ✅ API側の型チェック・リント・ユニットテスト: 全て成功
- ✅ フロントエンド側のユニットテスト: 関連箇所は成功（既存の失敗テストは今回の修正とは無関係）

## 関連Issue
Closes #363

## 動作確認
サブスクリプション管理画面で新規登録を行い、以下を確認：
- カテゴリIDを選択せずに送信した場合、適切なバリデーションエラーが表示される
- 全ての必須項目を入力して送信した場合、正常に登録される

🤖 Generated with [Claude Code](https://claude.ai/code)