### PR TITLE
fix: issue-364 サブスクリプション登録時のカテゴリIDエラーを修正

### DIFF
--- a/e2e/tests/subscription.spec.ts
+++ b/e2e/tests/subscription.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('サブスクリプション管理機能', () => {
+  test('サブスクリプションの登録が正常に動作すること', async ({ page }) => {
+    // タイムスタンプを使って一意なテストデータを作成
+    const timestamp = Date.now();
+    const testServiceName = `[E2E_TEST] テストサブスク ${timestamp}`;
+    
+    // ホーム画面からサブスクリプション管理画面へ遷移
+    await page.goto('/');
+    await page.getByRole('link', { name: 'サブスクリプション管理ページへ移動' }).click();
+    
+    // サブスクリプション管理画面が表示されることを確認
+    await expect(page).toHaveURL(/\/subscriptions/);
+    
+    // 新規サブスクリプションを登録
+    await page.getByRole('button', { name: '新しいサブスクリプションを登録' }).click();
+    
+    // フォームに入力（一意なデータ）
+    await page.getByRole('textbox', { name: 'サービス名 *' }).fill(testServiceName);
+    await page.getByRole('spinbutton', { name: '料金（円） *' }).fill('1500');
+    await page.getByRole('textbox', { name: '次回請求日 *' }).fill('2025-07-24');
+    await page.getByLabel('カテゴリ *').selectOption('6'); // system_feeのnumericId
+    await page.getByRole('textbox', { name: '説明（任意）' }).fill('E2Eテスト用のサブスクリプション');
+    
+    // 登録ボタンをクリック
+    await page.getByRole('button', { name: '登録', exact: true }).click();
+    
+    // フォームが閉じることを確認（モーダルやフォームが消えるのを待つ）
+    await expect(page.getByRole('button', { name: '登録', exact: true })).not.toBeVisible();
+    
+    // 登録したサブスクリプションが一覧に表示されることを確認
+    // 一意なテストデータを使って確実に特定
+    const newRow = page.locator('tr', { hasText: testServiceName }).first();
+    await expect(newRow).toBeVisible();
+    await expect(newRow.locator('text=/1[,，]500/')).toBeVisible();
+  });
+});

--- a/frontend/src/app/subscriptions/page.tsx
+++ b/frontend/src/app/subscriptions/page.tsx
@@ -70,6 +70,9 @@ const SubscriptionsPage: FC = () => {
 				// 成功時にダイアログを閉じる
 				handleCloseDialog();
 
+				// サブスクリプション一覧を再取得
+				await refetchSubscriptions();
+
 				// 成功フィードバック（将来的にはトーストやスナックバーなどを使用）
 				console.log("新しいサブスクリプションを登録しました");
 			} catch (error) {
@@ -77,7 +80,7 @@ const SubscriptionsPage: FC = () => {
 				// エラーはフォーム内で表示されるため、ここでは特別な処理不要
 			}
 		},
-		[createSubscriptionMutation, handleCloseDialog],
+		[createSubscriptionMutation, handleCloseDialog, refetchSubscriptions],
 	);
 
 	return (

--- a/frontend/src/components/subscriptions/NewSubscriptionDialog.tsx
+++ b/frontend/src/components/subscriptions/NewSubscriptionDialog.tsx
@@ -48,7 +48,7 @@ export const NewSubscriptionDialog: FC<NewSubscriptionDialogProps> = ({
 		// グローバル設定から支出カテゴリを取得してCategory型に変換
 		const globalExpenseCategories = getCategoriesByType("expense");
 		return globalExpenseCategories.map((config) => ({
-			id: config.id,
+			id: config.numericId.toString(), // numericIdを文字列に変換してidとして使用
 			name: config.name,
 			type: config.type,
 			color: config.color,


### PR DESCRIPTION
## Summary
- カテゴリ選択時にnumericIdを使用するよう修正
- 登録後に一覧が自動更新されるよう修正
- サブスクリプション登録のE2Eテストを追加

## Issue
Fixes #364 

## Changes
1. **フロントエンドのカテゴリID送信の修正**
   - `NewSubscriptionDialog.tsx`: カテゴリ選択時にnumericIdを文字列に変換して使用
   - APIはカテゴリIDを数値として期待しているため、数値IDを送信するよう修正

2. **登録後の一覧更新処理の追加**
   - `subscriptions/page.tsx`: 登録成功後に`refetchSubscriptions()`を呼び出して一覧を更新

3. **E2Eテストの追加**
   - `subscription.spec.ts`: サブスクリプション登録の正常系テストを追加

## Test plan
- [x] ローカルでサブスクリプション登録が正常に動作することを確認
- [x] E2Eテストが通過することを確認
- [x] 型チェック・リントが通過することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)